### PR TITLE
Catalogue client : onglet « Nos suggestions » + suggestion de produit par le client

### DIFF
--- a/src/@types/product.ts
+++ b/src/@types/product.ts
@@ -32,6 +32,13 @@ export type Product = {
   inCatalogue: boolean;
   productRef?: string;
   refVisibleToCustomer?: boolean;
+  /**
+   * Produit mis en avant dans l'onglet « Nos suggestions » du catalogue client.
+   * Champ Strapi à déployer côté backend (peg_strapi) — le frontend détecte sa
+   * disponibilité via `apiIsSuggestedFieldAvailable` et bascule sur les
+   * nouveautés tant qu'il n'existe pas.
+   */
+  suggested?: boolean;
   requiresBat?: boolean;
   batFile?: PegFile | null;
   catalogPrice?: number | null;

--- a/src/services/ProductServices.ts
+++ b/src/services/ProductServices.ts
@@ -400,6 +400,147 @@ export async function apiGetCustomerProducts(customerDocumentId: string, custome
     })
 }
 
+// ─── Suggestions catalogue (onglet client « Nos suggestions ») ───────────────
+// Le champ booléen `suggested` doit être ajouté au schéma produit côté
+// peg_strapi (backend d'abord, comme catalogPrice). Tant qu'il n'est pas
+// déployé, toute requête qui l'utilise renvoie une erreur GraphQL : on sonde
+// donc sa disponibilité une fois (cache mémoire) et on se replie sur les
+// nouveautés du catalogue.
+
+let suggestedFieldAvailable: boolean | null = null;
+
+export async function apiIsSuggestedFieldAvailable(): Promise<boolean> {
+    if (suggestedFieldAvailable !== null) return suggestedFieldAvailable;
+    try {
+        const response = await ApiService.fetchData<{data?: unknown, errors?: unknown[]}>({
+            url: API_GRAPHQL_URL,
+            method: 'post',
+            data: {
+                query: `query ProbeSuggestedField { products_connection(filters: {suggested: {eq: true}}, pagination: {pageSize: 1}) { pageInfo { total } } }`,
+            },
+        });
+        suggestedFieldAvailable = !response.data?.errors;
+    } catch {
+        suggestedFieldAvailable = false;
+    }
+    return suggestedFieldAvailable;
+}
+
+const SUGGESTED_PRODUCT_FIELDS = `
+                images {
+                    url
+                }
+                description
+                documentId
+                name
+                price
+                priceTiers
+                pricingMode
+                pricePerM2
+                minM2
+                productCategory {
+                    documentId
+                    name
+                }`;
+
+export type SuggestedProductsResult = {
+    products: Product[];
+    /** true = sélection marquée par l'admin (champ suggested), false = fallback nouveautés */
+    curated: boolean;
+};
+
+export async function apiGetSuggestedProducts(): Promise<SuggestedProductsResult> {
+    if (await apiIsSuggestedFieldAvailable()) {
+        try {
+            const response = await ApiService.fetchData<ApiResponse<{products_connection: GetProductsResponse}>>({
+                url: API_GRAPHQL_URL,
+                method: 'post',
+                data: {
+                    query: `
+    query GetSuggestedProducts($pagination: PaginationArg) {
+        products_connection (filters: {
+        and: [
+            {suggested: {eq: true}},
+            {active: {eq: true}},
+            {inCatalogue: {eq: true}}
+        ]},
+        pagination: $pagination, sort: "updatedAt:desc") {
+            nodes {${SUGGESTED_PRODUCT_FIELDS}
+            }
+            pageInfo {
+                page
+                pageSize
+                pageCount
+                total
+            }
+        }
+    }
+  `,
+                    variables: { pagination: { page: 1, pageSize: 24 } },
+                },
+            });
+            const nodes = response.data.data?.products_connection?.nodes ?? [];
+            if (nodes.length > 0) return { products: nodes, curated: true };
+        } catch (error) {
+            console.error('[Suggestions] Échec requête produits suggérés:', error);
+        }
+    }
+    // Fallback : les nouveautés du catalogue
+    const response = await ApiService.fetchData<ApiResponse<{products_connection: GetProductsResponse}>>({
+        url: API_GRAPHQL_URL,
+        method: 'post',
+        data: {
+            query: `
+    query GetNewestCatalogueProducts($pagination: PaginationArg) {
+        products_connection (filters: {
+        and: [
+            {active: {eq: true}},
+            {inCatalogue: {eq: true}}
+        ]},
+        pagination: $pagination, sort: "createdAt:desc") {
+            nodes {${SUGGESTED_PRODUCT_FIELDS}
+            }
+            pageInfo {
+                page
+                pageSize
+                pageCount
+                total
+            }
+        }
+    }
+  `,
+            variables: { pagination: { page: 1, pageSize: 12 } },
+        },
+    });
+    return { products: response.data.data?.products_connection?.nodes ?? [], curated: false };
+}
+
+// Lecture isolée du flag suggested d'un produit (formulaire admin) — requête
+// séparée pour ne pas casser apiGetProductForEditById tant que le champ
+// n'existe pas côté Strapi.
+export async function apiGetProductSuggestedFlag(documentId: string): Promise<boolean> {
+    if (!(await apiIsSuggestedFieldAvailable())) return false;
+    try {
+        const response = await ApiService.fetchData<ApiResponse<{product: {suggested?: boolean}}>>({
+            url: API_GRAPHQL_URL,
+            method: 'post',
+            data: {
+                query: `
+    query GetProductSuggestedFlag($documentId: ID!) {
+        product(documentId: $documentId) {
+            suggested
+        }
+    }
+  `,
+                variables: { documentId },
+            },
+        });
+        return response.data.data?.product?.suggested ?? false;
+    } catch {
+        return false;
+    }
+}
+
 // update product
 export async function apiUpdateProduct(product: Partial<Product>): Promise<AxiosResponse<ApiResponse<{updateProduct: Product}>>> {
     const query = `

--- a/src/views/app/admin/products/product/EditProduct.tsx
+++ b/src/views/app/admin/products/product/EditProduct.tsx
@@ -8,7 +8,12 @@ import {
   apiGetCustomers,
   GetCustomersResponse,
 } from '@/services/CustomerServices';
-import { apiCreateProduct, apiUpdateProduct } from '@/services/ProductServices';
+import {
+  apiCreateProduct,
+  apiGetProductSuggestedFlag,
+  apiIsSuggestedFieldAvailable,
+  apiUpdateProduct,
+} from '@/services/ProductServices';
 import { toast } from 'react-toastify';
 import { apiGetForms, GetFormsResponse } from '@/services/FormServices';
 import { Form } from '@/@types/form';
@@ -69,6 +74,9 @@ const EditProduct = () => {
   const [images, setImages] = useState<PegFile[]>([]);
   const [imagesLoading, setImagesLoading] = useState<boolean>(false);
   const [currentStep, setCurrentStep] = useState(0);
+  // Champ `suggested` : disponible seulement une fois déployé côté Strapi
+  const [suggestedAvailable, setSuggestedAvailable] = useState(false);
+  const [initialSuggested, setInitialSuggested] = useState(false);
   const initialData: ProductFormModel = useMemo(() => ({
     documentId: documentId ?? '',
     name: product?.name || '',
@@ -98,13 +106,26 @@ const EditProduct = () => {
     pricePerM2: product?.pricePerM2 ?? undefined,
     minM2: product?.minM2 ?? undefined,
     cost: product?.cost ?? undefined,
-  }), [product?.documentId]);
+    suggested: initialSuggested,
+  }), [product?.documentId, initialSuggested]);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
+    const loadSuggested = async () => {
+      const available = await apiIsSuggestedFieldAvailable();
+      setSuggestedAvailable(available);
+      if (available && onEdition) {
+        setInitialSuggested(await apiGetProductSuggestedFlag(documentId));
+      }
+    };
     if (onEdition) {
-      dispatch(getProductById(documentId)).finally(() => setInitialLoading(false));
+      // Attendre aussi le flag suggested : il alimente les defaultValues du
+      // formulaire, figées au premier rendu de ProductForm
+      Promise.all([dispatch(getProductById(documentId)), loadSuggested()]).finally(
+        () => setInitialLoading(false)
+      );
     } else {
+      loadSuggested();
       setInitialLoading(false);
     }
     return () => {
@@ -317,6 +338,9 @@ const EditProduct = () => {
       delete data.pricingMode;
       delete data.pricePerM2;
       delete data.minM2;
+      if (!suggestedAvailable) {
+        delete data.suggested;
+      }
 
       await updateOrCreateProduct(data);
       navigate('/admin/products');
@@ -355,6 +379,7 @@ const EditProduct = () => {
         imagesLoading={imagesLoading}
         currentBatUrl={product?.batFile?.url ?? null}
         initialData={initialData}
+        showSuggested={suggestedAvailable}
         currentStep={currentStep}
         setCurrentStep={setCurrentStep}
         filterSizesListByProductCategory={filterSizesListByProductCategory}

--- a/src/views/app/admin/products/product/Forms/ProductFields.tsx
+++ b/src/views/app/admin/products/product/Forms/ProductFields.tsx
@@ -43,6 +43,8 @@ type ProductFieldsProps = {
   batFile: PegFile | null;
   setBatFile: (f: PegFile | null) => void;
   currentBatUrl?: string | null;
+  /** Affiche le toggle « Suggestion client » (champ suggested déployé côté Strapi) */
+  showSuggested?: boolean;
   currentStep?: number;
 };
 
@@ -101,6 +103,7 @@ const ProductFields = (props: ProductFieldsProps) => {
     batFile,
     setBatFile,
     currentBatUrl,
+    showSuggested,
     currentStep,
   } = props;
 
@@ -277,6 +280,23 @@ const ProductFields = (props: ProductFieldsProps) => {
                 {watch('inCatalogue') ? 'Visible' : 'Masqué'}
               </span>
             </div>
+            {showSuggested && (
+              <>
+                <label style={{ ...fieldLabel, marginTop: '14px' }}>Suggestion client</label>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginTop: '6px' }}>
+                  <Controller
+                    name="suggested"
+                    control={control}
+                    render={({ field }) => (
+                      <Switcher checked={field.value} onChange={(val) => field.onChange(!val)} />
+                    )}
+                  />
+                  <span style={{ color: 'rgba(255,255,255,0.6)', fontSize: '12px' }}>
+                    {watch('suggested') ? 'Mis en avant' : 'Non suggéré'}
+                  </span>
+                </div>
+              </>
+            )}
           </div>
         </div>
 

--- a/src/views/app/admin/products/product/Forms/ProductForm.tsx
+++ b/src/views/app/admin/products/product/Forms/ProductForm.tsx
@@ -72,6 +72,8 @@ type ProductFormProps = {
   setImages: (images: PegFile[]) => void;
   imagesLoading: boolean;
   currentBatUrl?: string | null;
+  /** Affiche le toggle « Suggestion client » (champ suggested déployé côté Strapi) */
+  showSuggested?: boolean;
   currentStep: number;
   setCurrentStep: (step: number | ((s: number) => number)) => void;
   filterSizesListByProductCategory: (productCategoryDocumentId: string) => void;
@@ -122,6 +124,7 @@ const ProductForm = (props: ProductFormProps) => {
     setImages,
     imagesLoading,
     currentBatUrl,
+    showSuggested,
     currentStep,
     setCurrentStep,
     filterSizesListByProductCategory,
@@ -278,6 +281,7 @@ const ProductForm = (props: ProductFormProps) => {
               batFile={batFile}
               setBatFile={setBatFile}
               currentBatUrl={currentBatUrl}
+              showSuggested={showSuggested}
               currentStep={currentStep}
             />
           </div>

--- a/src/views/app/customer/catalogue/components/SuggestionsTab.tsx
+++ b/src/views/app/customer/catalogue/components/SuggestionsTab.tsx
@@ -1,0 +1,332 @@
+import { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
+import { HiOutlineLightBulb, HiOutlineSparkles, HiX } from 'react-icons/hi';
+import { Product } from '@/@types/product';
+import { User } from '@/@types/user';
+import { RootState, useAppSelector } from '@/store';
+import { apiGetSuggestedProducts } from '@/services/ProductServices';
+import { apiCreateTicket } from '@/services/TicketServices';
+import { triggerNotification } from '@/services/NotificationService';
+import CustomerProductCard from '../../products/lists/CustomerProductCard';
+
+const SkeletonCard = () => (
+  <div style={{
+    background: 'linear-gradient(160deg, #16263d 0%, #0f1c2e 100%)',
+    borderRadius: '18px',
+    overflow: 'hidden',
+    boxShadow: '0 4px 20px rgba(0,0,0,0.3)',
+  }}>
+    <div style={{ height: '200px', background: 'rgba(255,255,255,0.04)', animation: 'pulse 1.5s ease-in-out infinite' }} />
+    <div style={{ padding: '14px 16px 16px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
+      <div style={{ height: '14px', borderRadius: '6px', background: 'rgba(255,255,255,0.07)', width: '75%' }} />
+      <div style={{ height: '10px', borderRadius: '6px', background: 'rgba(255,255,255,0.04)', width: '55%' }} />
+      <div style={{ height: '32px', borderRadius: '10px', background: 'rgba(255,255,255,0.04)', marginTop: '8px' }} />
+    </div>
+  </div>
+);
+
+const inputStyle: React.CSSProperties = {
+  width: '100%', background: 'rgba(0,0,0,0.3)', border: '1px solid rgba(255,255,255,0.1)',
+  borderRadius: '10px', color: '#fff', fontSize: '13px', padding: '12px 14px',
+  outline: 'none', fontFamily: 'inherit', boxSizing: 'border-box',
+};
+const labelStyle: React.CSSProperties = {
+  color: 'rgba(255,255,255,0.4)', fontSize: '11px', fontWeight: 600, letterSpacing: '0.05em',
+  textTransform: 'uppercase', marginBottom: '6px', display: 'block',
+};
+
+const SuggestionsTab = () => {
+  const { user }: { user?: User } = useAppSelector(
+    (state: RootState) => state.auth.user
+  );
+  const [products, setProducts] = useState<Product[]>([]);
+  const [curated, setCurated] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  // Modal « Suggérer un produit »
+  const [modalOpen, setModalOpen] = useState(false);
+  const [sugName, setSugName] = useState('');
+  const [sugDescription, setSugDescription] = useState('');
+  const [sugQuantity, setSugQuantity] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiGetSuggestedProducts()
+      .then((result) => {
+        if (cancelled) return;
+        setProducts(result.products);
+        setCurated(result.curated);
+      })
+      .catch((err) => {
+        console.error('[Suggestions] Échec chargement:', err);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const resetModal = () => {
+    setModalOpen(false);
+    setSugName('');
+    setSugDescription('');
+    setSugQuantity('');
+  };
+
+  const submitSuggestion = async () => {
+    if (!sugName.trim()) {
+      toast.error('Indiquez le produit souhaité');
+      return;
+    }
+    if (!user?.documentId) {
+      toast.error('Utilisateur non identifié');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const description = [
+        sugDescription.trim() && `Besoin : ${sugDescription.trim()}`,
+        sugQuantity.trim() && `Quantité estimée : ${sugQuantity.trim()}`,
+      ]
+        .filter(Boolean)
+        .join('\n');
+      await apiCreateTicket({
+        name: `Suggestion produit — ${sugName.trim()}`,
+        description,
+        state: 'pending',
+        priority: 'medium',
+        type: 'features',
+        user: user.documentId,
+      } as any);
+
+      const rawSenderId = user?.documentId || (user as any)?.id || (user as any)?._id;
+      const senderId = rawSenderId != null ? String(rawSenderId) : undefined;
+      if (senderId) {
+        triggerNotification({
+          eventType: 'new_ticket',
+          senderId,
+          notifyAdmins: true,
+          title: 'Suggestion de produit',
+          message: `${user.customer?.name || `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim() || 'Un client'} suggère « ${sugName.trim()} » pour le catalogue`,
+          link: '/support',
+        });
+      }
+      toast.success("Merci ! Votre suggestion a été transmise à l'équipe PEG.");
+      resetModal();
+    } catch (err) {
+      console.error('[Suggestions] Échec envoi suggestion:', err);
+      toast.error("Erreur lors de l'envoi de la suggestion");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div style={{ fontFamily: 'Inter, sans-serif' }}>
+      {/* Header */}
+      <div style={{ marginBottom: '20px' }}>
+        <h3 style={{ margin: 0, color: '#fff', fontSize: '20px', fontWeight: 700, display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <HiOutlineSparkles size={22} style={{ color: '#a99bff' }} />
+          Nos suggestions
+        </h3>
+        <p style={{ margin: '4px 0 0', color: 'rgba(255,255,255,0.35)', fontSize: '13px' }}>
+          {curated
+            ? 'Une sélection de produits choisie pour vous par l\'équipe PEG'
+            : 'Les dernières nouveautés du catalogue'}
+        </p>
+      </div>
+
+      {/* Grid */}
+      {loading ? (
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+          gap: '20px',
+        }}>
+          {Array.from({ length: 8 }).map((_, i) => <SkeletonCard key={i} />)}
+        </div>
+      ) : products.length === 0 ? (
+        <div style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '60px 20px',
+          gap: '12px',
+          textAlign: 'center',
+        }}>
+          <div style={{
+            width: '72px',
+            height: '72px',
+            borderRadius: '20px',
+            background: 'rgba(255,255,255,0.04)',
+            border: '1px solid rgba(255,255,255,0.08)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}>
+            <HiOutlineSparkles size={28} style={{ color: 'rgba(255,255,255,0.2)' }} />
+          </div>
+          <p style={{ color: 'rgba(255,255,255,0.6)', fontSize: '16px', fontWeight: 600, margin: 0 }}>
+            Aucune suggestion pour le moment
+          </p>
+          <p style={{ color: 'rgba(255,255,255,0.55)', fontSize: '13px', margin: 0 }}>
+            Revenez bientôt, ou dites-nous ce que vous cherchez ci-dessous
+          </p>
+        </div>
+      ) : (
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+          gap: '20px',
+        }}>
+          {products.map((product) => (
+            <CustomerProductCard key={product.documentId} product={product} />
+          ))}
+        </div>
+      )}
+
+      {/* Encart « Suggérer un produit » */}
+      <div style={{
+        marginTop: '32px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: '20px',
+        flexWrap: 'wrap',
+        padding: '24px 28px',
+        borderRadius: '18px',
+        background: 'radial-gradient(120% 160% at 80% 12%, rgba(124,107,255,0.22) 0%, rgba(91,71,224,0.07) 42%, rgba(10,12,22,0.2) 72%), linear-gradient(160deg, #12152a 0%, #0a0c16 100%)',
+        border: '1px solid rgba(124,107,255,0.25)',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '16px', minWidth: 0 }}>
+          <div style={{
+            width: '48px', height: '48px', borderRadius: '14px', flexShrink: 0,
+            background: 'rgba(124,107,255,0.14)', border: '1px solid rgba(124,107,255,0.3)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#a99bff',
+          }}>
+            <HiOutlineLightBulb size={24} />
+          </div>
+          <div>
+            <p style={{ color: '#fff', fontSize: '15px', fontWeight: 700, margin: 0 }}>
+              Vous ne trouvez pas votre bonheur ?
+            </p>
+            <p style={{ color: 'rgba(255,255,255,0.5)', fontSize: '13px', margin: '4px 0 0' }}>
+              Dites-nous quel produit vous aimeriez voir au catalogue, notre équipe étudiera votre demande.
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={() => setModalOpen(true)}
+          style={{
+            display: 'flex', alignItems: 'center', gap: '8px', padding: '11px 20px', borderRadius: '12px',
+            background: 'linear-gradient(135deg, #6d5dfc, #5a47e0)', border: 'none', cursor: 'pointer', color: '#fff',
+            fontSize: '13px', fontWeight: 700, fontFamily: 'Inter, sans-serif',
+            boxShadow: '0 4px 16px rgba(109,93,252,0.4)', whiteSpace: 'nowrap',
+          }}
+        >
+          <HiOutlineLightBulb size={16} />
+          Suggérer un produit
+        </button>
+      </div>
+
+      {/* Modal suggestion */}
+      {modalOpen && (
+        <div
+          onClick={resetModal}
+          style={{
+            position: 'fixed', inset: 0, zIndex: 1000,
+            background: 'rgba(0,0,0,0.65)', backdropFilter: 'blur(4px)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '20px',
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              width: '100%', maxWidth: '480px',
+              background: 'linear-gradient(160deg, #16263d 0%, #0f1c2e 100%)',
+              border: '1px solid rgba(255,255,255,0.1)', borderRadius: '18px',
+              padding: '26px', fontFamily: 'Inter, sans-serif',
+              boxShadow: '0 24px 64px rgba(0,0,0,0.5)',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '18px' }}>
+              <h4 style={{ color: '#fff', fontSize: '17px', fontWeight: 700, margin: 0, display: 'flex', alignItems: 'center', gap: '10px' }}>
+                <HiOutlineLightBulb size={20} style={{ color: '#a99bff' }} />
+                Suggérer un produit
+              </h4>
+              <button
+                onClick={resetModal}
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'rgba(255,255,255,0.5)', padding: '4px', display: 'flex' }}
+              >
+                <HiX size={18} />
+              </button>
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+              <div>
+                <label style={labelStyle}>Produit souhaité *</label>
+                <input
+                  value={sugName}
+                  onChange={(e) => setSugName(e.target.value)}
+                  placeholder="Ex : Gourde isotherme personnalisée"
+                  style={inputStyle}
+                />
+              </div>
+              <div>
+                <label style={labelStyle}>Décrivez votre besoin</label>
+                <textarea
+                  value={sugDescription}
+                  onChange={(e) => setSugDescription(e.target.value)}
+                  placeholder="Usage, matière, personnalisation attendue…"
+                  rows={4}
+                  style={{ ...inputStyle, resize: 'vertical' }}
+                />
+              </div>
+              <div>
+                <label style={labelStyle}>Quantité estimée</label>
+                <input
+                  value={sugQuantity}
+                  onChange={(e) => setSugQuantity(e.target.value)}
+                  placeholder="Ex : 200 pièces"
+                  style={inputStyle}
+                />
+              </div>
+            </div>
+
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px', marginTop: '22px' }}>
+              <button
+                onClick={resetModal}
+                style={{
+                  padding: '10px 18px', borderRadius: '12px', border: '1px solid rgba(255,255,255,0.12)',
+                  background: 'rgba(255,255,255,0.04)', color: 'rgba(255,255,255,0.7)',
+                  fontSize: '13px', fontWeight: 600, cursor: 'pointer', fontFamily: 'Inter, sans-serif',
+                }}
+              >
+                Annuler
+              </button>
+              <button
+                onClick={submitSuggestion}
+                disabled={submitting}
+                style={{
+                  padding: '10px 20px', borderRadius: '12px', border: 'none',
+                  background: submitting ? 'rgba(109,93,252,0.4)' : 'linear-gradient(135deg, #6d5dfc, #5a47e0)',
+                  color: '#fff', fontSize: '13px', fontWeight: 700,
+                  cursor: submitting ? 'wait' : 'pointer', fontFamily: 'Inter, sans-serif',
+                  boxShadow: '0 4px 16px rgba(109,93,252,0.4)',
+                }}
+              >
+                {submitting ? 'Envoi…' : 'Envoyer ma suggestion'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SuggestionsTab;

--- a/src/views/app/customer/catalogue/index.tsx
+++ b/src/views/app/customer/catalogue/index.tsx
@@ -6,8 +6,9 @@ import reducer, {
   getCatalogueProductCategories,
   useAppSelector,
 } from './store';
-import { HiSearch } from 'react-icons/hi';
+import { HiOutlineSparkles, HiOutlineViewGrid, HiSearch } from 'react-icons/hi';
 import CatalogueBanner from '@/views/app/common/categories/CatalogueBanner';
+import SuggestionsTab from './components/SuggestionsTab';
 
 injectReducer('catalogue', reducer);
 
@@ -32,7 +33,13 @@ const SkeletonCard = () => (
   }} />
 );
 
+const TABS: { key: 'categories' | 'suggestions'; label: string; icon: JSX.Element }[] = [
+  { key: 'categories', label: 'Catégories', icon: <HiOutlineViewGrid size={15} /> },
+  { key: 'suggestions', label: 'Nos suggestions', icon: <HiOutlineSparkles size={15} /> },
+];
+
 const Categories = () => {
+  const [activeTab, setActiveTab] = useState<'categories' | 'suggestions'>('categories');
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(16);
   const [searchTerm, setSearchTerm] = useState('');
@@ -85,6 +92,35 @@ const Categories = () => {
         maxHeight="380px"
       />
 
+      {/* Onglets Catégories / Suggestions */}
+      <div style={{ display: 'flex', gap: '8px', margin: '20px 0 24px' }}>
+        {TABS.map((tab) => {
+          const active = activeTab === tab.key;
+          return (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              style={{
+                display: 'flex', alignItems: 'center', gap: '7px',
+                padding: '9px 18px', borderRadius: '100px', cursor: 'pointer',
+                border: active ? '1px solid rgba(109,93,252,0.5)' : '1px solid rgba(255,255,255,0.1)',
+                background: active ? 'rgba(109,93,252,0.16)' : 'rgba(255,255,255,0.03)',
+                color: active ? '#a99bff' : 'rgba(255,255,255,0.55)',
+                fontSize: '13px', fontWeight: 600, fontFamily: 'Inter, sans-serif',
+                transition: 'all 0.15s',
+              }}
+            >
+              {tab.icon}
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {activeTab === 'suggestions' ? (
+        <SuggestionsTab />
+      ) : (
+      <>
       {/* Grid */}
       {loading ? (
         <div style={{
@@ -150,6 +186,8 @@ const Categories = () => {
             />
           </div>
         </div>
+      )}
+      </>
       )}
     </div>
   );


### PR DESCRIPTION
## Résumé

Ajoute un onglet **« Nos suggestions »** dans le catalogue client (`/customer/catalogue`), qui combine :

1. **Produits mis en avant** — sélection curatée par l'admin via un nouveau champ booléen `suggested` sur le produit (Strapi), affichée avec les cartes produit existantes (`CustomerProductCard`, remise premium −15 % incluse).
2. **Encart « Vous ne trouvez pas votre bonheur ? »** — modal permettant au client de suggérer un produit à ajouter au catalogue. La suggestion crée un **ticket** (type `features`, titre préfixé `Suggestion produit — `) et notifie les admins via le système de notifications existant (`new_ticket`, `notifyAdmins: true`).

## Fonctionnement sans déploiement backend (fallback)

Le champ `suggested` **n'existe pas encore côté peg_strapi**. Le frontend sonde sa disponibilité via une requête GraphQL (`apiIsSuggestedFieldAvailable`, résultat mis en cache) :

- Champ absent → l'onglet affiche automatiquement les **nouveautés du catalogue** (12 derniers produits `active` + `inCatalogue`, tri `createdAt:desc`) et le toggle admin est masqué + retiré du payload de sauvegarde (même pattern que `catalogPrice`/`pricingMode`).
- Champ déployé → l'onglet bascule sur la sélection admin (tri `updatedAt:desc`) sans aucun changement frontend, et le toggle **« Suggestion client »** apparaît dans le formulaire produit admin (step « Infos de base », à côté de « Dans le catalogue »).

## À faire côté backend (peg_strapi) pour activer la curation

Ajouter au schéma produit (`src/api/product/content-types/product/schema.json`) :
```json
"suggested": { "type": "boolean", "default": false }
```
Déploiement backend d'abord (intégration → prod), le frontend s'adapte tout seul.

## Fichiers modifiés

- `src/views/app/customer/catalogue/index.tsx` — barre d'onglets Catégories / Nos suggestions
- `src/views/app/customer/catalogue/components/SuggestionsTab.tsx` — **nouveau** : grille de suggestions + encart + modal
- `src/services/ProductServices.ts` — `apiIsSuggestedFieldAvailable`, `apiGetSuggestedProducts` (avec fallback), `apiGetProductSuggestedFlag`
- `src/@types/product.ts` — champ `suggested?: boolean`
- `src/views/app/admin/products/product/EditProduct.tsx` + `Forms/ProductForm.tsx` + `Forms/ProductFields.tsx` — toggle admin conditionnel

## Tests

- `npx tsc --noEmit` ✅
- `npm run build` (Vite) ✅
- `npx jest src/__tests__/terminology-guard.test.ts` — 39/39 ✅
- Parcours UI à valider sur https://int.mypeg.fr après push sur `front-test` (nécessite un compte client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3mL15pLpBeRsL73HKmc6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3mL15pLpBeRsL73HKmc6H)_