### PR TITLE
Tailles/Couleurs : correction des retraits de catégories qui « reviennent »

### DIFF
--- a/src/services/ColorServices.ts
+++ b/src/services/ColorServices.ts
@@ -136,6 +136,12 @@ export type UpdateColorRequest = {
   value?: string;
   description?: string;
   productCategories?: string[];
+  /**
+   * Relation historique (oneToOne). Passer `null` pour la purger : sinon la
+   * migration bootstrap de peg_strapi la recopie dans `productCategories` à
+   * chaque redémarrage et les retraits de catégories « reviennent ».
+   */
+  productCategory?: string | null;
 };
 
 export async function apiUpdateColor(

--- a/src/services/SizeServices.ts
+++ b/src/services/SizeServices.ts
@@ -133,6 +133,12 @@ export type UpdateSizeRequest = {
   value?: string;
   description?: string;
   productCategories?: string[];
+  /**
+   * Relation historique (oneToOne). Passer `null` pour la purger : sinon la
+   * migration bootstrap de peg_strapi la recopie dans `productCategories` à
+   * chaque redémarrage et les retraits de catégories « reviennent ».
+   */
+  productCategory?: string | null;
 };
 
 export async function apiUpdateSize(

--- a/src/views/app/admin/products/colors/ColorsList.tsx
+++ b/src/views/app/admin/products/colors/ColorsList.tsx
@@ -57,10 +57,13 @@ const normalizeHex = (input: string): string => {
 const isValidHex = (input: string): boolean =>
   /^#[0-9a-fA-F]{6}$/.test(normalizeHex(input));
 
-// Catégories d'une couleur (relation multiple, fallback ancien champ unique)
+// Catégories d'une couleur (relation multiple). Le fallback sur l'ancien champ
+// unique ne s'applique QUE si `productCategories` est absent (backend pas
+// encore déployé) — pas si la liste est vide : sinon, retirer la dernière
+// catégorie d'une couleur encore porteuse de la relation historique la fait
+// « revenir » à l'écran alors que l'enregistrement a réussi.
 const colorCategories = (c: Color): ProductCategory[] => {
-  if (c.productCategories && c.productCategories.length)
-    return c.productCategories;
+  if (c.productCategories) return c.productCategories;
   if (c.productCategory) return [c.productCategory];
   return [];
 };
@@ -446,6 +449,7 @@ const ColorsList = () => {
               value: ec.e.value,
               description: ec.e.description || '',
               productCategories: [...ec.cats],
+              productCategory: null,
             })
           );
           if (r.meta.requestStatus === 'fulfilled') saved++;
@@ -501,6 +505,7 @@ const ColorsList = () => {
               value: existing.value,
               description: existing.description || '',
               productCategories: union,
+              productCategory: null,
             })
           );
           if (r.meta.requestStatus === 'fulfilled')
@@ -562,6 +567,7 @@ const ColorsList = () => {
               value: existing.value,
               description: existing.description || '',
               productCategories: union,
+              productCategory: null,
             })
           );
           if (r.meta.requestStatus === 'fulfilled') updated++;
@@ -626,6 +632,7 @@ const ColorsList = () => {
           value: normalizeHex(formValue),
           description: formDescription,
           productCategories: formCategories.map((c) => c.value),
+          productCategory: null,
         })
       );
       if (result.meta.requestStatus === 'fulfilled') {
@@ -661,6 +668,7 @@ const ColorsList = () => {
         value: color.value,
         description: color.description || '',
         productCategories: remaining,
+        productCategory: null,
       })
     );
     if (result.meta.requestStatus === 'fulfilled') {

--- a/src/views/app/admin/products/sizes/SizesList.tsx
+++ b/src/views/app/admin/products/sizes/SizesList.tsx
@@ -88,10 +88,13 @@ const compareSizes = (a: Size, b: Size): number => {
   return String(va).localeCompare(String(vb));
 };
 
-// Catégories d'une taille (relation multiple, fallback ancien champ unique)
+// Catégories d'une taille (relation multiple). Le fallback sur l'ancien champ
+// unique ne s'applique QUE si `productCategories` est absent (backend pas
+// encore déployé) — pas si la liste est vide : sinon, retirer la dernière
+// catégorie d'une taille encore porteuse de la relation historique la fait
+// « revenir » à l'écran alors que l'enregistrement a réussi.
 const sizeCategories = (s: Size): ProductCategory[] => {
-  if (s.productCategories && s.productCategories.length)
-    return s.productCategories;
+  if (s.productCategories) return s.productCategories;
   if (s.productCategory) return [s.productCategory];
   return [];
 };
@@ -231,11 +234,17 @@ const SizesList = () => {
     compareSizes({ name: a.name } as Size, { name: b.name } as Size)
   );
 
-  // Parse quick input into trimmed names
-  const parsedSizes = quickInput
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
+  // Parse quick input into trimmed names — dédupliqué (insensible à la casse) :
+  // « S, s » ne doit créer qu'une seule entité
+  const parsedSizes = Array.from(
+    new Map(
+      quickInput
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .map((n) => [n.toLowerCase(), n])
+    ).values()
+  );
 
   // Noms de tailles déjà existants (toutes catégories confondues) → fusion plutôt que doublon
   const existingNamesSet = new Set(
@@ -311,6 +320,7 @@ const SizesList = () => {
               value: ec.e.value || ec.e.name,
               description: ec.e.description || '',
               productCategories: [...ec.cats],
+              productCategory: null,
             })
           );
           if (r.meta.requestStatus === 'fulfilled') saved++;
@@ -367,6 +377,7 @@ const SizesList = () => {
               value: existing.value || existing.name,
               description: existing.description || '',
               productCategories: union,
+              productCategory: null,
             })
           );
           r.meta.requestStatus === 'fulfilled' ? updated++ : errors++;
@@ -438,6 +449,7 @@ const SizesList = () => {
           value: formName,
           description: formDescription,
           productCategories: formCategories.map((c) => c.value),
+          productCategory: null,
         })
       );
       if (result.meta.requestStatus === 'fulfilled') {
@@ -473,6 +485,7 @@ const SizesList = () => {
         value: size.value || size.name,
         description: size.description || '',
         productCategories: remaining,
+        productCategory: null,
       })
     );
     if (result.meta.requestStatus === 'fulfilled') {


### PR DESCRIPTION
## Problème constaté

Dans les modules admin **Tailles** et **Couleurs**, retirer une taille/couleur d'une catégorie (croix sur la puce, décoche dans le tableau croisé, ou multi-select du modal) semblait ne pas s'enregistrer : le toast affichait un succès, mais la catégorie **réapparaissait** immédiatement ou après un rechargement.

## Cause racine

Le champ historique `productCategory` (relation oneToOne conservée pour compatibilité depuis la migration multi-catégories du 01/06) n'était **jamais purgé** par les mutations, et jouait contre nous deux fois :

1. **Fallback d'affichage** : `sizeCategories()`/`colorCategories()` retombaient sur le champ historique dès que `productCategories` était **vide** — donc retirer la *dernière* catégorie d'une entité migrée réussissait côté serveur, mais l'UI réaffichait l'ancienne catégorie via le fallback. La case se « recochait » toute seule.
2. **Migration bootstrap de peg_strapi** : au démarrage du backend, la migration idempotente recopie `productCategory` → `productCategories`. Toute catégorie retirée côté front **revenait en base** au redéploiement suivant, tant que le champ historique restait rempli.

## Correctifs

- Chaque `updateSize`/`updateColor` envoie désormais **`productCategory: null`** pour purger la relation historique (5 points d'appel par module : tableau croisé, création rapide, templates couleurs, modal d'édition, retrait d'une catégorie). Le champ existe toujours dans le schéma Strapi — aucun déploiement backend requis.
- Le **fallback d'affichage** sur le champ historique ne s'applique plus que si `productCategories` est absent de la réponse (backend non déployé), plus quand la liste est vide.
- Bonus : la création rapide de tailles **déduplique la saisie** (insensible à la casse) — « S, s » créait deux entités.

## Fichiers modifiés

- `src/services/SizeServices.ts`, `src/services/ColorServices.ts` — type Update + doc du champ historique
- `src/views/app/admin/products/sizes/SizesList.tsx` — fallback, 4 mutations, dédup création rapide
- `src/views/app/admin/products/colors/ColorsList.tsx` — fallback, 5 mutations

## Tests

- `npx tsc --noEmit` ✅
- `npm run build` (Vite) ✅
- `npx jest src/__tests__/terminology-guard.test.ts` — 39/39 ✅
- À vérifier en réel : retirer une taille d'une catégorie via la croix → recharger la page → elle ne doit plus revenir

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3mL15pLpBeRsL73HKmc6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3mL15pLpBeRsL73HKmc6H)_