### PR TITLE
fix(invoices): pagination réelle + base de tests unitaires métier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+# Vérifie le typage, les tests unitaires et le build à chaque push et
+# pull request. Objectif : détecter une régression AVANT le déploiement
+# (tarification, remises Premium, permissions, tri des tailles…).
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
+
+# Annule un run précédent encore en cours sur la même réf (push rapides).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Typecheck & tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Unit tests
+        run: npm test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,11 @@ name: CI
 # (tarification, remises Premium, permissions, tri des tailles…).
 
 on:
+  # Sur les branches de déploiement, on garde un run direct au push.
   push:
-    branches: ['**']
+    branches: [main, front-test]
+  # Pour les branches de fonctionnalité, le run se fait via la pull request
+  # (évite le double run push + PR sur un même commit).
   pull_request:
     branches: ['**']
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,9 @@ module.exports = {
   transform: {
     "^.+.tsx?$": ["ts-jest", {}],
   },
+  // Résolution de l'alias "@/..." → "src/..." (identique à Vite/tsconfig)
+  // pour que les tests puissent importer les utilitaires applicatifs.
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
 };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
+    "test": "jest",
+    "test:watch": "jest --watch",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "lint": "eslint src/views --ext .js,.jsx,.ts,.tsx",

--- a/src/__tests__/priceHelpers.test.ts
+++ b/src/__tests__/priceHelpers.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests unitaires — calculs de TVA et formatage de prix.
+ *
+ * priceHelpers lit `localStorage` (masquage des prix) et émet un événement
+ * `window` au toggle. L'environnement de test étant Node, on installe des
+ * stubs minimaux avant chaque test.
+ */
+
+import {
+  TVA_RATE,
+  toTTC,
+  toHT,
+  tvaAmount,
+  fmtNum,
+  fmtPrice,
+  fmtHT,
+  fmtTTC,
+  fmtEur,
+  arePricesHidden,
+  togglePricesHidden,
+} from '@/utils/priceHelpers';
+
+// ── Stubs navigateur (localStorage + window.dispatchEvent/Event) ──
+beforeEach(() => {
+  const store: Record<string, string> = {};
+  (global as any).localStorage = {
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => {
+      store[k] = String(v);
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k];
+    },
+  };
+  (global as any).Event = class {
+    type: string;
+    constructor(type: string) {
+      this.type = type;
+    }
+  };
+  (global as any).window = { dispatchEvent: jest.fn() };
+});
+
+describe('Calculs TVA (20 %)', () => {
+  test('taux de TVA = 0.2', () => {
+    expect(TVA_RATE).toBe(0.2);
+  });
+
+  test('HT vers TTC', () => {
+    expect(toTTC(100)).toBe(120);
+    expect(toTTC(19.99)).toBe(23.99); // 19.99 x 1.2 = 23.988 -> 23.99
+  });
+
+  test('TTC vers HT', () => {
+    expect(toHT(120)).toBe(100);
+  });
+
+  test('montant de TVA sur un HT', () => {
+    expect(tvaAmount(100)).toBe(20);
+    expect(tvaAmount(33.33)).toBe(6.67); // 6.666 -> 6.67
+  });
+
+  test('aller-retour HT vers TTC vers HT reste coherent', () => {
+    expect(toHT(toTTC(250))).toBe(250);
+  });
+});
+
+describe('Formatage numerique (locale FR)', () => {
+  test('virgule comme separateur decimal, 2 decimales par defaut', () => {
+    // La virgule decimale FR est stable ; le separateur de milliers depend de
+    // l'ICU de Node, on ne teste donc que la partie decimale.
+    expect(fmtNum(1234.5)).toMatch(/,50$/);
+    expect(fmtNum(9.9)).toBe('9,90');
+  });
+
+  test('respecte le nombre de decimales demande', () => {
+    expect(fmtNum(10, 0)).toBe('10');
+  });
+});
+
+describe('Formatage prix — affichage normal', () => {
+  test('fmtPrice ajoute le symbole euro', () => {
+    expect(fmtPrice(50)).toContain('€');
+    expect(fmtPrice(50)).toContain('50,00');
+  });
+
+  test('fmtHT suffixe « € HT »', () => {
+    expect(fmtHT(50)).toContain('€ HT');
+  });
+
+  test('fmtTTC suffixe « € TTC »', () => {
+    expect(fmtTTC(50)).toContain('€ TTC');
+  });
+
+  test('fmtEur formate en devise sans decimales', () => {
+    const out = fmtEur(1500);
+    expect(out).toContain('€');
+    expect(out).not.toContain(',00');
+  });
+});
+
+describe('Masquage des prix', () => {
+  test('prix non masques par defaut', () => {
+    expect(arePricesHidden()).toBe(false);
+  });
+
+  test('toggle masque puis demasque', () => {
+    expect(togglePricesHidden()).toBe(true);
+    expect(arePricesHidden()).toBe(true);
+    expect(togglePricesHidden()).toBe(false);
+    expect(arePricesHidden()).toBe(false);
+  });
+
+  test('les formateurs renvoient le placeholder quand masque', () => {
+    togglePricesHidden(); // -> masque
+    expect(fmtPrice(50)).toBe('•••••');
+    expect(fmtHT(50)).toBe('•••••');
+    expect(fmtTTC(50)).toBe('•••••');
+    expect(fmtEur(50)).toBe('•••••');
+  });
+
+  test('le toggle emet un evenement window', () => {
+    togglePricesHidden();
+    expect((global as any).window.dispatchEvent).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/productHelpers.test.ts
+++ b/src/__tests__/productHelpers.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests unitaires — logique produit / tarification.
+ * Couvre la remise Premium (−15 %), le prix de base, les paliers de quantité,
+ * la tarification packs / m², la visibilité catalogue et les marges.
+ *
+ * Ce sont des fonctions pures : aucun mock nécessaire.
+ */
+
+import {
+  PREMIUM_DISCOUNT_RATE,
+  getPremiumMultiplier,
+  applyPremiumDiscount,
+  getProductBasePrice,
+  getProductCost,
+  getCatalogueVisibilityIssues,
+  getUnitMargin,
+  getMarginRate,
+  getProductPriceForQuantity,
+  getProductPriceForSizeAndColors,
+  getProductPackOptions,
+  isProductPackPricing,
+  isProductM2Pricing,
+  getM2Price,
+  getCatalogSavingsPercent,
+  getTotalPriceForCartItem,
+} from '@/utils/productHelpers';
+import { Product, SizeAndColorSelection } from '@/@types/product';
+import { Customer } from '@/@types/customer';
+
+// Fabriques minimales : on ne renseigne que les champs utilisés par les helpers.
+const makeProduct = (overrides: Partial<Product> = {}): Product =>
+  ({ price: 100, ...overrides } as Product);
+const makeCustomer = (premium: boolean): Customer =>
+  ({ premium } as Customer);
+const sel = (
+  quantity: number,
+  extra: Partial<SizeAndColorSelection> = {}
+): SizeAndColorSelection => ({ quantity, ...extra } as SizeAndColorSelection);
+
+describe('Remise Premium', () => {
+  test('le taux de remise est bien 15 %', () => {
+    expect(PREMIUM_DISCOUNT_RATE).toBe(0.15);
+  });
+
+  test('multiplicateur = 0.85 pour un client Premium', () => {
+    expect(getPremiumMultiplier(makeCustomer(true))).toBe(0.85);
+  });
+
+  test('multiplicateur = 1 pour un client standard', () => {
+    expect(getPremiumMultiplier(makeCustomer(false))).toBe(1);
+  });
+
+  test('multiplicateur = 1 sans client (null/undefined)', () => {
+    expect(getPremiumMultiplier(null)).toBe(1);
+    expect(getPremiumMultiplier(undefined)).toBe(1);
+  });
+
+  test('applique −15 % et arrondit au centime', () => {
+    expect(applyPremiumDiscount(100, makeCustomer(true))).toBe(85);
+    // 33.33 × 0.85 = 28.3305 → 28.33
+    expect(applyPremiumDiscount(33.33, makeCustomer(true))).toBe(28.33);
+  });
+
+  test('ne modifie pas le prix pour un client standard', () => {
+    expect(applyPremiumDiscount(100, makeCustomer(false))).toBe(100);
+  });
+});
+
+describe('Prix de base et coût', () => {
+  test('retourne product.price en l\'absence de paliers', () => {
+    expect(getProductBasePrice(makeProduct({ price: 42 }))).toBe(42);
+  });
+
+  test('retourne 0 si aucun prix', () => {
+    expect(getProductBasePrice(makeProduct({ price: undefined }))).toBe(0);
+  });
+
+  test('privilégie le premier palier de prix si présent', () => {
+    const p = makeProduct({
+      price: 100,
+      priceTiers: [
+        { minQuantity: 1, price: 90 },
+        { minQuantity: 10, price: 80 },
+      ],
+    });
+    expect(getProductBasePrice(p)).toBe(90);
+  });
+
+  test('coût produit : valeur ou 0 par défaut', () => {
+    expect(getProductCost(makeProduct({ cost: 12.5 }))).toBe(12.5);
+    expect(getProductCost(makeProduct({ cost: undefined }))).toBe(0);
+    expect(getProductCost(null)).toBe(0);
+    expect(getProductCost(makeProduct({ cost: 0 }))).toBe(0);
+  });
+});
+
+describe('Paliers de quantité', () => {
+  const tiered = makeProduct({
+    price: 100,
+    priceTiers: [
+      { minQuantity: 1, price: 100 },
+      { minQuantity: 10, price: 80 },
+      { minQuantity: 50, price: 60 },
+    ],
+  });
+
+  test('choisit le palier applicable le plus élevé', () => {
+    expect(getProductPriceForQuantity(tiered, 1)).toBe(100);
+    expect(getProductPriceForQuantity(tiered, 9)).toBe(100);
+    expect(getProductPriceForQuantity(tiered, 10)).toBe(80);
+    expect(getProductPriceForQuantity(tiered, 49)).toBe(80);
+    expect(getProductPriceForQuantity(tiered, 50)).toBe(60);
+    expect(getProductPriceForQuantity(tiered, 1000)).toBe(60);
+  });
+
+  test('sous le premier palier → prix de base (= 1er palier quand des paliers existent)', () => {
+    // getProductBasePrice retourne priceTiers[0].price dès qu'un palier existe,
+    // indépendamment de sa minQuantity → fallback à 70, pas au champ price legacy.
+    const p = makeProduct({ price: 100, priceTiers: [{ minQuantity: 5, price: 70 }] });
+    expect(getProductPriceForQuantity(p, 1)).toBe(70);
+  });
+
+  test('somme les quantités des tailles/couleurs pour choisir le palier', () => {
+    const price = getProductPriceForSizeAndColors(tiered, [sel(6), sel(6)]);
+    expect(price).toBe(80); // total 12 ≥ 10
+  });
+
+  test('options de packs = minQuantity uniques triées', () => {
+    expect(getProductPackOptions(tiered)).toEqual([1, 10, 50]);
+    expect(getProductPackOptions(makeProduct({ priceTiers: [] }))).toEqual([]);
+  });
+});
+
+describe('Modes de tarification', () => {
+  test('détecte le mode packs', () => {
+    expect(isProductPackPricing(makeProduct({ pricingMode: 'packs' }))).toBe(true);
+    expect(isProductPackPricing(makeProduct({ pricingMode: 'm2' }))).toBe(false);
+  });
+
+  test('détecte le mode m²', () => {
+    expect(isProductM2Pricing(makeProduct({ pricingMode: 'm2' }))).toBe(true);
+    expect(isProductM2Pricing(makeProduct({ pricingMode: 'packs' }))).toBe(false);
+  });
+
+  test('prix m² = surface × prix/m² × quantité, avec surface mini', () => {
+    const p = makeProduct({ pricePerM2: 20, minM2: 0.5 });
+    // 1 × 2 = 2 m² × 20 € × 3 = 120
+    expect(getM2Price(p, 1, 2, 3)).toEqual({ area: 2, pricePerUnit: 40, total: 120 });
+    // 0.1 × 0.1 = 0.01 → forcé au mini 0.5 m² × 20 = 10
+    expect(getM2Price(p, 0.1, 0.1, 1)).toEqual({ area: 0.5, pricePerUnit: 10, total: 10 });
+  });
+});
+
+describe('Total panier', () => {
+  test('mode standard : prix unitaire × quantité totale', () => {
+    const p = makeProduct({ price: 25 });
+    expect(getTotalPriceForCartItem(p, [sel(2), sel(3)])).toBe(125); // 25 × 5
+  });
+
+  test('mode packs : le prix du palier EST le total', () => {
+    const p = makeProduct({
+      pricingMode: 'packs',
+      priceTiers: [
+        { minQuantity: 10, price: 200 },
+        { minQuantity: 20, price: 350 },
+      ],
+    });
+    // total 20 → palier 350, pas ×20
+    expect(getTotalPriceForCartItem(p, [sel(10), sel(10)])).toBe(350);
+  });
+
+  test('mode m² : somme des surfaces facturées', () => {
+    const p = makeProduct({ pricingMode: 'm2', pricePerM2: 10 });
+    // (1×1×10×2) + (2×1×10×1) = 20 + 20 = 40
+    const total = getTotalPriceForCartItem(p, [
+      sel(2, { width: 1, height: 1 }),
+      sel(1, { width: 2, height: 1 }),
+    ]);
+    expect(total).toBe(40);
+  });
+});
+
+describe('Marges', () => {
+  test('marge unitaire = vente − coût, arrondie au centime', () => {
+    expect(getUnitMargin(50, 30)).toBe(20);
+    expect(getUnitMargin(99.999, 0)).toBe(100); // arrondi au centime supérieur
+  });
+
+  test('taux de marge en % sur le prix de vente', () => {
+    expect(getMarginRate(100, 60)).toBe(40);
+    expect(getMarginRate(80, 60)).toBe(25);
+  });
+
+  test('taux de marge indéfini si prix de vente nul', () => {
+    expect(getMarginRate(0, 60)).toBeNull();
+    expect(getMarginRate(-5, 60)).toBeNull();
+  });
+});
+
+describe('Visibilité catalogue', () => {
+  const visible = makeProduct({
+    active: true,
+    inCatalogue: true,
+    productCategory: { name: 'Vêtements', active: true } as any,
+  });
+
+  test('aucun problème pour un produit visible', () => {
+    expect(getCatalogueVisibilityIssues(visible)).toEqual([]);
+  });
+
+  test('signale produit inactif', () => {
+    expect(getCatalogueVisibilityIssues({ ...visible, active: false })).toContain(
+      'Produit inactif'
+    );
+  });
+
+  test('signale hors catalogue', () => {
+    expect(getCatalogueVisibilityIssues({ ...visible, inCatalogue: false })).toContain(
+      'Hors catalogue'
+    );
+  });
+
+  test('signale l\'absence de catégorie', () => {
+    expect(
+      getCatalogueVisibilityIssues({ ...visible, productCategory: undefined } as unknown as Product)
+    ).toContain('Aucune catégorie rattachée');
+  });
+
+  test('signale une catégorie inactive', () => {
+    const issues = getCatalogueVisibilityIssues({
+      ...visible,
+      productCategory: { name: 'Old', active: false } as any,
+    });
+    expect(issues.some((i) => i.includes('inactive'))).toBe(true);
+  });
+});
+
+describe('Économie catalogue', () => {
+  test('% d\'économie vs prix catalogue public', () => {
+    const p = makeProduct({ price: 80, catalogPrice: 100 });
+    expect(getCatalogSavingsPercent(p)).toBe(20);
+  });
+
+  test('null si pas de prix catalogue', () => {
+    expect(getCatalogSavingsPercent(makeProduct({ catalogPrice: undefined }))).toBeNull();
+  });
+
+  test('null si aucune économie (prix ≥ catalogue)', () => {
+    expect(getCatalogSavingsPercent(makeProduct({ price: 120, catalogPrice: 100 }))).toBeNull();
+  });
+});

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests unitaires — utilitaires transverses :
+ *  - permissions (hasRole)
+ *  - correspondance de noms insensible aux accents (nameMatch)
+ *  - tri naturel des tailles (sizeSort)
+ *  - marqueur d'image d'origine encode dans le nom (pegOrigRef)
+ *
+ * Ces modules ont ete a l'origine de bugs metier reels (categories non
+ * trouvees a cause des accents, tailles dans le desordre, conflit de logos),
+ * d'ou une couverture explicite.
+ */
+
+import { hasRole } from '@/utils/permissions';
+import { normalizeName, sameName } from '@/utils/nameMatch';
+import { compareSizeNames, sortSizes } from '@/utils/sizeSort';
+import {
+  parsePegOrigRef,
+  stripPegOrigMarker,
+  buildPegOrigName,
+} from '@/utils/pegOrigRef';
+import { User } from '@/@types/user';
+
+const makeUser = (roleName?: string): User =>
+  (roleName ? { role: { name: roleName } } : {}) as User;
+
+describe('Permissions — hasRole', () => {
+  test('vrai si le role de l\'utilisateur est dans la liste', () => {
+    expect(hasRole(makeUser('admin'), ['admin', 'super_admin'])).toBe(true);
+  });
+
+  test('faux si le role n\'est pas dans la liste', () => {
+    expect(hasRole(makeUser('customer'), ['admin', 'super_admin'])).toBe(false);
+  });
+
+  test('faux pour un utilisateur sans role', () => {
+    expect(hasRole(makeUser(), ['admin'])).toBe(false);
+  });
+
+  test('faux pour un utilisateur null/undefined', () => {
+    expect(hasRole(null as any, ['admin'])).toBe(false);
+    expect(hasRole(undefined as any, ['admin'])).toBe(false);
+  });
+
+  test('faux avec une liste de roles vide', () => {
+    expect(hasRole(makeUser('admin'), [])).toBe(false);
+  });
+});
+
+describe('Correspondance de noms (accents/casse/espaces)', () => {
+  test('normalise accents, casse et espaces surnumeraires', () => {
+    expect(normalizeName('  Vetement   Haute-Visibilite ')).toBe(
+      'vetement haute-visibilite'
+    );
+    expect(normalizeName('Vêtement Haute-Visibilité')).toBe(
+      'vetement haute-visibilite'
+    );
+  });
+
+  test('chaine vide / null / undefined -> chaine vide', () => {
+    expect(normalizeName('')).toBe('');
+    expect(normalizeName(null)).toBe('');
+    expect(normalizeName(undefined)).toBe('');
+  });
+
+  test('sameName rapproche deux libelles equivalents malgre les accents', () => {
+    expect(sameName('Vêtement', 'vetement')).toBe(true);
+    expect(sameName('  ROUGE ', 'rouge')).toBe(true);
+  });
+
+  test('sameName distingue deux libelles differents', () => {
+    expect(sameName('Rouge', 'Bleu')).toBe(false);
+  });
+
+  test('sameName est faux si l\'un des libelles est vide', () => {
+    expect(sameName('', 'rouge')).toBe(false);
+    expect(sameName(null, null)).toBe(false);
+  });
+});
+
+describe('Tri naturel des tailles', () => {
+  test('ordonne les tailles lettres XS < S < M < L < XL < XXL', () => {
+    const sorted = sortSizes(
+      ['XL', 'S', 'XXL', 'M', 'XS', 'L'].map((name) => ({ name }))
+    ).map((s) => s.name);
+    expect(sorted).toEqual(['XS', 'S', 'M', 'L', 'XL', 'XXL']);
+  });
+
+  test('gere les alias 2XL = XXL, 3XL = XXXL', () => {
+    // 2XL doit se placer comme XXL (apres XL), 3XL apres.
+    expect(compareSizeNames('XL', '2XL')).toBeLessThan(0);
+    expect(compareSizeNames('2XL', '3XL')).toBeLessThan(0);
+  });
+
+  test('ordonne les pointures numeriques', () => {
+    const sorted = sortSizes(
+      ['42', '38', '40', '39'].map((name) => ({ name }))
+    ).map((s) => s.name);
+    expect(sorted).toEqual(['38', '39', '40', '42']);
+  });
+
+  test('les tailles lettres passent avant les numeriques', () => {
+    const sorted = sortSizes(
+      ['40', 'M', '38', 'S'].map((name) => ({ name }))
+    ).map((s) => s.name);
+    expect(sorted).toEqual(['S', 'M', '38', '40']);
+  });
+
+  test('ne mute pas le tableau d\'origine', () => {
+    const input = [{ name: 'XL' }, { name: 'S' }];
+    const copy = [...input];
+    sortSizes(input);
+    expect(input).toEqual(copy);
+  });
+});
+
+describe('Marqueur image d\'origine (pegOrigRef)', () => {
+  test('parse un nom tamponne', () => {
+    expect(parsePegOrigRef('visuel__pegorig-12-abcDEF123.png')).toEqual({
+      id: '12',
+      documentId: 'abcDEF123',
+    });
+  });
+
+  test('retourne null si pas de marqueur', () => {
+    expect(parsePegOrigRef('visuel.png')).toBeNull();
+    expect(parsePegOrigRef(undefined)).toBeNull();
+  });
+
+  test('retire le marqueur du nom', () => {
+    expect(stripPegOrigMarker('visuel__pegorig-12-abc.png')).toBe('visuel.png');
+    expect(stripPegOrigMarker('visuel.png')).toBe('visuel.png');
+  });
+
+  test('construit un nom tamponne avec extension preservee', () => {
+    const name = buildPegOrigName('logo.png', { id: '7', documentId: 'xyz' });
+    expect(name).toBe('logo__pegorig-7-xyz.png');
+    expect(parsePegOrigRef(name)).toEqual({ id: '7', documentId: 'xyz' });
+  });
+
+  test('remplace un marqueur existant au lieu de le cumuler', () => {
+    const once = buildPegOrigName('logo.png', { id: '1', documentId: 'aaa' });
+    const twice = buildPegOrigName(once, { id: '2', documentId: 'bbb' });
+    expect(twice).toBe('logo__pegorig-2-bbb.png');
+    // un seul marqueur present
+    expect((twice.match(/__pegorig-/g) || []).length).toBe(1);
+  });
+
+  test('gere un nom sans extension', () => {
+    const name = buildPegOrigName('logo', { id: '3', documentId: 'ccc' });
+    expect(name).toBe('logo__pegorig-3-ccc');
+    expect(parsePegOrigRef(name)).toEqual({ id: '3', documentId: 'ccc' });
+  });
+});

--- a/src/views/app/common/invoices/InvoicesList.tsx
+++ b/src/views/app/common/invoices/InvoicesList.tsx
@@ -14,6 +14,7 @@ import { HiOutlineSearch, HiPencil, HiPrinter, HiBan, HiDocumentText, HiTrash, H
 import { FaPiggyBank } from 'react-icons/fa';
 import { fmtPrice, fmtHT, fmtTTC, fmtEur, fmtNum } from '@/utils/priceHelpers';
 import { PREMIUM_DISCOUNT_RATE } from '@/utils/productHelpers';
+import { Pagination } from '@/components/ui';
 
 injectReducer('invoices', reducer);
 
@@ -402,6 +403,16 @@ const InvoicesList = () => {
                   </div>
                 )
               })}
+            </div>
+          )}
+          {!loading && total > pageSize && (
+            <div style={{ display: 'flex', justifyContent: 'center', marginTop: '16px', paddingTop: '4px' }}>
+              <Pagination
+                total={total}
+                currentPage={currentPage}
+                pageSize={pageSize}
+                onChange={(page) => setCurrentPage(page)}
+              />
             </div>
           )}
         </Panel>


### PR DESCRIPTION
Cette PR regroupe deux améliorations issues de l'audit du site.

## 1. Correctif — pagination réelle sur la liste des factures

La liste des factures (`InvoicesList.tsx`) chargeait déjà les données **page par page** côté serveur (`pageSize = 50`, `total` disponible), mais **aucun contrôle de pagination n'était affiché** → au-delà de 50 factures, les plus anciennes étaient **inaccessibles**.

- Import de `<Pagination>` depuis `@/components/ui` (pattern identique à `ProjectsList.tsx`).
- Rendu sous la liste, câblé sur `total` / `currentPage` / `pageSize`, affiché uniquement quand `!loading && total > pageSize`.
- Le `useEffect` de fetch réagit déjà à `currentPage` → le changement de page recharge la bonne tranche côté serveur.

## 2. Base de tests unitaires (67 tests)

Le projet n'avait qu'un test de non-régression terminologique. Ajout d'une couverture sur les **fonctions pures les plus sensibles**, à l'origine de bugs métier réels :

| Suite | Portée | Tests |
|---|---|---|
| `productHelpers.test.ts` | Remise Premium −15 %, prix de base, paliers de quantité, packs/m², visibilité catalogue, marges | 31 |
| `priceHelpers.test.ts` | TVA 20 %, formatage prix FR, masquage des prix | 15 |
| `utils.test.ts` | `hasRole`, `normalizeName` (accents catégories), tri naturel des tailles, marqueur `pegorig` | 21 |

**Config :**
- `jest.config.js` : `moduleNameMapper` `@/` → `src/` pour importer les utilitaires applicatifs.
- `package.json` : scripts `test` / `test:watch`.

## Vérifications

- `npx tsc --noEmit` ✅
- `npm run build` ✅
- `npx jest` → **106 tests verts** (39 existants + 67 nouveaux) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)