### PR TITLE
test: reducer panier + modules services testables (couverture étendue)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,12 +1,23 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
 module.exports = {
   testEnvironment: "node",
+  // On ne considère comme suites que les fichiers *.test.ts(x) : les fichiers
+  // utilitaires/mocks placés sous src/__tests__ ne sont donc pas exécutés.
+  testMatch: ["**/*.test.ts?(x)"],
+  // Certains modules importés (services notifications/socket) laissent un
+  // timer ouvert au chargement : forceExit garantit une sortie propre en CI.
+  forceExit: true,
   transform: {
     "^.+.tsx?$": ["ts-jest", {}],
   },
   // Résolution de l'alias "@/..." → "src/..." (identique à Vite/tsconfig)
   // pour que les tests puissent importer les utilitaires applicatifs.
+  // env.config utilise import.meta.env (Vite) : on le remplace par un stub
+  // Node-compatible en test uniquement (n'affecte pas le build).
   moduleNameMapper: {
+    // Intercepte aussi bien l'import alias "@/configs/env.config" que l'import
+    // relatif "./env.config" (utilisé dans api.config.ts).
+    "(^|/)env\\.config$": "<rootDir>/src/__tests__/__mocks__/env.config.ts",
     "^@/(.*)$": "<rootDir>/src/$1",
   },
 };

--- a/src/__tests__/__mocks__/env.config.ts
+++ b/src/__tests__/__mocks__/env.config.ts
@@ -1,0 +1,15 @@
+/**
+ * Stub jest de src/configs/env.config.ts.
+ *
+ * Le vrai module utilise `import.meta.env` (spécifique à Vite), non
+ * interprétable par ts-jest en environnement Node. Ce stub reproduit la
+ * MÊME forme (`env` avec les mêmes clés) pour que les modules qui importent
+ * les services (donc api.config -> env.config) soient testables.
+ *
+ * Câblé via moduleNameMapper dans jest.config.js — n'affecte PAS le build Vite.
+ */
+export const env = {
+  API_ENDPOINT_URL: 'http://localhost:1337',
+  EXPRESS_BACKEND_URL: 'http://localhost:3000',
+  STRIPE_PUBLIC_KEY: '',
+};

--- a/src/__tests__/cartSlice.test.ts
+++ b/src/__tests__/cartSlice.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests unitaires — reducer panier (cartSlice).
+ *
+ * Le panier a ete a l'origine d'un bug reel (confirmation de paiement qui
+ * echouait a vider le panier -> repli sur clearCart). On verrouille ici le
+ * comportement de chaque reducer, testes comme des fonctions pures
+ * reducer(state, action).
+ */
+
+import reducer, {
+  addToCart,
+  removeFromCart,
+  removeFromCartItemOfOrderItem,
+  editSizeAndColorsCartItem,
+  editFormAnswerCartItem,
+  editOrderItemDocumentIdCartItem,
+  clearCart,
+  initialState,
+  CartState,
+} from '@/store/slices/base/cartSlice';
+import { CartItem } from '@/@types/cart';
+
+// Fabrique un CartItem minimal (on ne renseigne que les champs manipules).
+const makeItem = (id: string, extra: Partial<CartItem> = {}): CartItem =>
+  ({
+    id,
+    userDocumentId: 'user-1',
+    sizeAndColors: [],
+    formAnswer: { answers: [] },
+    product: { name: `p-${id}` },
+    ...extra,
+  } as unknown as CartItem);
+
+const stateWith = (...items: CartItem[]): CartState => ({ cart: items });
+
+describe('cartSlice — ajout / suppression', () => {
+  test('etat initial : panier vide', () => {
+    expect(initialState).toEqual({ cart: [] });
+  });
+
+  test('addToCart ajoute un article', () => {
+    const next = reducer(initialState, addToCart(makeItem('a')));
+    expect(next.cart).toHaveLength(1);
+    expect(next.cart[0].id).toBe('a');
+  });
+
+  test('addToCart n\'altere pas l\'etat d\'origine (immutabilite)', () => {
+    const start = stateWith(makeItem('a'));
+    const next = reducer(start, addToCart(makeItem('b')));
+    expect(start.cart).toHaveLength(1); // inchange
+    expect(next.cart).toHaveLength(2);
+  });
+
+  test('addToCart empile les articles dans l\'ordre', () => {
+    let s = reducer(initialState, addToCart(makeItem('a')));
+    s = reducer(s, addToCart(makeItem('b')));
+    expect(s.cart.map((i) => i.id)).toEqual(['a', 'b']);
+  });
+
+  test('removeFromCart retire l\'article par id', () => {
+    const start = stateWith(makeItem('a'), makeItem('b'), makeItem('c'));
+    const next = reducer(start, removeFromCart(makeItem('b')));
+    expect(next.cart.map((i) => i.id)).toEqual(['a', 'c']);
+  });
+
+  test('removeFromCart sur un id absent ne change rien', () => {
+    const start = stateWith(makeItem('a'));
+    const next = reducer(start, removeFromCart(makeItem('zzz')));
+    expect(next.cart.map((i) => i.id)).toEqual(['a']);
+  });
+
+  test('removeFromCartItemOfOrderItem retire par orderItemDocumentId', () => {
+    const start = stateWith(
+      makeItem('a', { orderItemDocumentId: 'oi-1' }),
+      makeItem('b', { orderItemDocumentId: 'oi-2' })
+    );
+    const next = reducer(start, removeFromCartItemOfOrderItem('oi-1'));
+    expect(next.cart.map((i) => i.id)).toEqual(['b']);
+  });
+
+  test('clearCart vide le panier', () => {
+    const start = stateWith(makeItem('a'), makeItem('b'));
+    const next = reducer(start, clearCart());
+    expect(next.cart).toEqual([]);
+  });
+
+  test('clearCart sur un panier deja vide reste vide', () => {
+    const next = reducer(initialState, clearCart());
+    expect(next.cart).toEqual([]);
+  });
+});
+
+describe('cartSlice — edition d\'un article', () => {
+  test('editSizeAndColorsCartItem met a jour tailles/couleurs du bon article', () => {
+    const start = stateWith(makeItem('a'), makeItem('b'));
+    const sizeAndColors = [{ quantity: 3 }] as any;
+    const next = reducer(
+      start,
+      editSizeAndColorsCartItem({
+        cartItemId: 'b',
+        formAnswer: { answers: [] } as any,
+        sizeAndColors,
+      })
+    );
+    expect(next.cart[1].sizeAndColors).toBe(sizeAndColors);
+    expect(next.cart[0].sizeAndColors).toEqual([]); // 'a' inchange
+  });
+
+  test('editFormAnswerCartItem met a jour la reponse de formulaire', () => {
+    const start = stateWith(makeItem('a'));
+    const formAnswer = { answers: [{ fieldId: 'f1', value: 'x' }] } as any;
+    const next = reducer(
+      start,
+      editFormAnswerCartItem({ cartItemId: 'a', formAnswer })
+    );
+    expect(next.cart[0].formAnswer).toEqual(formAnswer);
+  });
+
+  test('editOrderItemDocumentIdCartItem rattache l\'orderItem', () => {
+    const start = stateWith(makeItem('a'));
+    const next = reducer(
+      start,
+      editOrderItemDocumentIdCartItem({
+        cartItemId: 'a',
+        orderItemDocumentId: 'oi-42',
+      })
+    );
+    expect(next.cart[0].orderItemDocumentId).toBe('oi-42');
+  });
+
+  test('editer un cartItemId inexistant ne casse pas l\'etat', () => {
+    const start = stateWith(makeItem('a'));
+    const next = reducer(
+      start,
+      editOrderItemDocumentIdCartItem({
+        cartItemId: 'absent',
+        orderItemDocumentId: 'oi-99',
+      })
+    );
+    expect(next.cart[0].orderItemDocumentId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Poursuite de la couverture de tests entamée en #199, cette fois sur la logique **panier** et l'outillage pour tester les modules qui dépendent des services.

## Nouveaux tests (13)

`cartSlice.test.ts` — le reducer panier testé comme fonction pure `reducer(state, action)` :
- `addToCart` (ajout, ordre, immutabilité)
- `removeFromCart` / `removeFromCartItemOfOrderItem`
- `clearCart` (le repli utilisé après paiement — bug récent)
- `editSizeAndColorsCartItem` / `editFormAnswerCartItem` / `editOrderItemDocumentIdCartItem`
- robustesse sur id inexistant

## Outillage jest

Importer `cartSlice` tire toute la chaîne services → `api.config` → `env.config`, qui utilise `import.meta.env` (Vite), non interprétable par ts-jest.

- **Stub `env.config`** (`src/__tests__/__mocks__/env.config.ts`) reproduisant la même forme, câblé via `moduleNameMapper` (alias `@/` **et** import relatif `./env.config`). N'affecte **pas** le build Vite.
- `testMatch` limité à `*.test.ts(x)` → les fichiers utilitaires/mocks sous `__tests__` ne sont plus pris pour des suites.
- `forceExit` → sortie propre malgré les timers ouverts au chargement par les services (socket/notifications).

Ces réglages débloquent les futurs tests de services/slices.

## Vérifications

- `npx tsc --noEmit` ✅
- `npm run build` ✅
- `npx jest` → **119 tests verts** (106 précédents + 13 nouveaux) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3mL15pLpBeRsL73HKmc6H)_