### PR TITLE
test: numérotation des factures (séquence FAC-XXXX)

### DIFF
--- a/src/__tests__/invoiceNumbering.test.ts
+++ b/src/__tests__/invoiceNumbering.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests unitaires — génération du prochain numéro de facture (FAC-XXXX).
+ *
+ * Séquence CRITIQUE : partagée PEG/NOVA. Un bug ici = collision de numéros
+ * de facture. On vérifie le calcul du max, le padding, l'ignorance des noms
+ * hors-format, et surtout que la fonction LÈVE une erreur au lieu de retomber
+ * silencieusement sur FAC-0001 quand la requête échoue.
+ *
+ * ApiService (couche réseau) est mocké : on teste la logique pure de la
+ * fonction, pas GraphQL.
+ */
+
+jest.mock('@/services/ApiService', () => ({
+  __esModule: true,
+  default: { fetchData: jest.fn() },
+}));
+
+import ApiService from '@/services/ApiService';
+import { apiGetNextInvoiceNumber } from '@/services/InvoicesServices';
+
+const mockFetch = (ApiService as unknown as { fetchData: jest.Mock }).fetchData;
+
+// Construit une réponse GraphQL valide à partir d'une liste de noms.
+const okResponse = (names: string[]) => ({
+  data: { data: { invoices_connection: { nodes: names.map((name) => ({ name })) } } },
+});
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('apiGetNextInvoiceNumber — calcul du numéro', () => {
+  test('aucune facture existante → FAC-0001', async () => {
+    mockFetch.mockResolvedValue(okResponse([]));
+    await expect(apiGetNextInvoiceNumber()).resolves.toBe('FAC-0001');
+  });
+
+  test('retourne max + 1, sur 4 chiffres', async () => {
+    mockFetch.mockResolvedValue(okResponse(['FAC-0007', 'FAC-0003', 'FAC-0005']));
+    await expect(apiGetNextInvoiceNumber()).resolves.toBe('FAC-0008');
+  });
+
+  test('ne dépend pas de l\'ordre des nœuds', async () => {
+    mockFetch.mockResolvedValue(okResponse(['FAC-0002', 'FAC-0042', 'FAC-0010']));
+    await expect(apiGetNextInvoiceNumber()).resolves.toBe('FAC-0043');
+  });
+
+  test('ignore les noms hors format FAC-XXXX (PDF uploadés, etc.)', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse(['FAC-0004', 'facture-scan.pdf', 'FAC-abc', 'FAC-0004-bis', 'DEVIS-0099'])
+    );
+    // seul FAC-0004 est valide → suivant = FAC-0005
+    await expect(apiGetNextInvoiceNumber()).resolves.toBe('FAC-0005');
+  });
+
+  test('ne tronque pas au-delà de 4 chiffres', async () => {
+    mockFetch.mockResolvedValue(okResponse(['FAC-9999']));
+    await expect(apiGetNextInvoiceNumber()).resolves.toBe('FAC-10000');
+  });
+
+  test('gère les numéros avec zéros non significatifs', async () => {
+    mockFetch.mockResolvedValue(okResponse(['FAC-0099', 'FAC-0100']));
+    await expect(apiGetNextInvoiceNumber()).resolves.toBe('FAC-0101');
+  });
+
+  test('nodes absent (null) → traité comme liste vide', async () => {
+    mockFetch.mockResolvedValue({
+      data: { data: { invoices_connection: { nodes: null } } },
+    });
+    await expect(apiGetNextInvoiceNumber()).resolves.toBe('FAC-0001');
+  });
+});
+
+describe('apiGetNextInvoiceNumber — garde-fous (pas de reset silencieux)', () => {
+  test('erreurs GraphQL → lève une erreur (jamais FAC-0001 silencieux)', async () => {
+    mockFetch.mockResolvedValue({
+      data: { errors: [{ message: 'boom' }] },
+    });
+    await expect(apiGetNextInvoiceNumber()).rejects.toThrow(/GraphQL/i);
+  });
+
+  test('réponse sans invoices_connection → lève une erreur', async () => {
+    mockFetch.mockResolvedValue({ data: { data: {} } });
+    await expect(apiGetNextInvoiceNumber()).rejects.toThrow(/invalide/i);
+  });
+});


### PR DESCRIPTION
Premier test de la **couche service**, rendu possible par l'outillage jest ajouté en #200. Cible : la génération du prochain numéro de facture — logique **critique** car la séquence `FAC-XXXX` est partagée entre PEG et NOVA (un bug = collision de numéros).

## Nouveaux tests (9) — `invoiceNumbering.test.ts`

`apiGetNextInvoiceNumber` testée avec `ApiService` (couche réseau) mocké :

**Calcul :**
- aucune facture → `FAC-0001`
- `max + 1`, padding sur 4 chiffres, indépendant de l'ordre des nœuds
- noms hors format ignorés (`facture-scan.pdf`, `FAC-abc`, `DEVIS-0099`…)
- pas de troncature au-delà de 4 chiffres (`FAC-9999` → `FAC-10000`)
- `nodes` null → traité comme liste vide

**Garde-fous (le point important) :**
- erreurs GraphQL → **lève une erreur** au lieu de retomber silencieusement sur `FAC-0001`
- réponse sans `invoices_connection` → lève une erreur

Ces deux derniers cas verrouillent le comportement anti-collision documenté dans `CLAUDE.md`.

## Vérifications

- `npx tsc --noEmit` ✅
- `npx jest` → **128 tests verts** (119 précédents + 9 nouveaux) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3mL15pLpBeRsL73HKmc6H)_