### PR TITLE
test: passerelle GraphQL unwrapData (gestion d'erreurs services)

### DIFF
--- a/src/__tests__/serviceHelper.test.ts
+++ b/src/__tests__/serviceHelper.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests unitaires — unwrapData (passerelle de gestion des réponses GraphQL).
+ *
+ * Tous les services de liste passent par cette fonction. Elle doit :
+ *  - renvoyer les données quand tout va bien,
+ *  - tolérer une réponse PARTIELLE (données + erreurs) en journalisant, sans
+ *    casser (comportement Strapi v5 fréquent : champ manquant côté prod),
+ *  - LEVER une erreur quand il n'y a que des erreurs et aucune donnée,
+ *  - ne jamais avaler une erreur sèche silencieusement.
+ */
+
+import { unwrapData } from '@/utils/serviceHelper';
+
+// Simule un AxiosResponse : seul .data est utilisé par unwrapData.
+const axiosLike = (payload: any) => Promise.resolve({ data: payload } as any);
+
+describe('unwrapData — cas nominal', () => {
+  test('renvoie response.data.data quand il n\'y a pas d\'erreur', async () => {
+    const data = { products: [{ id: 1 }] };
+    await expect(unwrapData(axiosLike({ data }))).resolves.toEqual(data);
+  });
+
+  test('renvoie les données même si le tableau errors est vide', async () => {
+    const data = { ok: true };
+    await expect(unwrapData(axiosLike({ data, errors: [] }))).resolves.toEqual(data);
+  });
+});
+
+describe('unwrapData — réponse partielle (données + erreurs)', () => {
+  test('renvoie les données et journalise un avertissement', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const data = { partial: 1 };
+    const res = await unwrapData(
+      axiosLike({ data, errors: [{ message: 'champ manquant' }] })
+    );
+    expect(res).toEqual(data);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('unwrapData — erreur sèche (aucune donnée)', () => {
+  test('lève avec le message de la première erreur', async () => {
+    await expect(
+      unwrapData(axiosLike({ data: null, errors: [{ message: 'Accès refusé' }] }))
+    ).rejects.toThrow('Accès refusé');
+  });
+
+  test('lève un message par défaut si l\'erreur n\'a pas de message', async () => {
+    await expect(
+      unwrapData(axiosLike({ data: null, errors: [{}] }))
+    ).rejects.toThrow('GraphQL error');
+  });
+
+  test('ne lève PAS quand data est présent malgré des erreurs', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    await expect(
+      unwrapData(axiosLike({ data: { x: 1 }, errors: [{ message: 'x' }] }))
+    ).resolves.toEqual({ x: 1 });
+    warn.mockRestore();
+  });
+});


### PR DESCRIPTION
Poursuite de la couverture de tests sur la couche service. Cible : `unwrapData`, la fonction par laquelle **tous les services de liste** passent pour dérouler une réponse GraphQL et gérer les erreurs.

## Pourquoi c'est important

Un bug ici a deux conséquences invisibles : soit une erreur GraphQL est **avalée silencieusement** (l'utilisateur voit une liste vide sans savoir pourquoi), soit une réponse partielle **fait planter** toute la vue. Le comportement attendu (documenté dans le code) est subtil, d'où le verrouillage par tests.

## Nouveaux tests (6) — `serviceHelper.test.ts`

- **Succès** : renvoie `response.data.data` ; tolère un tableau `errors` vide.
- **Réponse partielle** (données + erreurs) : renvoie les données et **journalise** un avertissement — cas fréquent en Strapi v5 quand un champ manque en prod, sans casser la vue.
- **Erreur sèche** (aucune donnée) : **lève** avec le message de la première erreur, ou un message par défaut si absent.
- **Non-régression** : ne lève jamais tant que `data` est présent.

## Vérifications

- `npx tsc --noEmit` ✅
- `npx jest` → **134 tests verts** (128 précédents + 6 nouveaux) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3mL15pLpBeRsL73HKmc6H)_