### PR TITLE
chore(lancement): SEO/partage, icônes et manifests prêts pour la mise en ligne

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,13 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#0f1c2e" />
     <meta
       http-equiv="Content-Security-Policy"
       content="
@@ -24,6 +28,36 @@
       content="MyPEG - Plateforme d'échanges graphiques"
     />
     <title>MyPEG - Plateforme d'échanges graphiques</title>
+
+    <!-- Canonique -->
+    <link rel="canonical" href="https://app.mypeg.fr/" />
+
+    <!-- Open Graph (aperçu de partage : LinkedIn, WhatsApp, Slack…) -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="MyPEG" />
+    <meta property="og:title" content="MyPEG - Plateforme d'échanges graphiques" />
+    <meta
+      property="og:description"
+      content="MyPEG - Plateforme d'échanges graphiques"
+    />
+    <meta property="og:url" content="https://app.mypeg.fr/" />
+    <meta property="og:locale" content="fr_FR" />
+    <meta
+      property="og:image"
+      content="https://app.mypeg.fr/android-chrome-512x512.png"
+    />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="MyPEG - Plateforme d'échanges graphiques" />
+    <meta
+      name="twitter:description"
+      content="MyPEG - Plateforme d'échanges graphiques"
+    />
+    <meta
+      name="twitter:image"
+      content="https://app.mypeg.fr/android-chrome-512x512.png"
+    />
   </head>
   <body>
     <noscript>Vous devez activer JavaScript pour exécuter cette application.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,25 +1,25 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "MyPEG",
+  "name": "MyPEG - Plateforme d'échanges graphiques",
   "icons": [
     {
-      "src": "favicon.ico",
+      "src": "/favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
     },
     {
-      "src": "logo192.png",
+      "src": "/android-chrome-192x192.png",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "logo512.png",
+      "src": "/android-chrome-512x512.png",
       "type": "image/png",
       "sizes": "512x512"
     }
   ],
-  "start_url": ".",
+  "start_url": "/",
   "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "theme_color": "#0f1c2e",
+  "background_color": "#0f1c2e"
 }

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,12 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "MyPEG - Plateforme d'échanges graphiques",
+  "short_name": "MyPEG",
+  "icons": [
+    { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#0f1c2e",
+  "background_color": "#0f1c2e"
+}


### PR DESCRIPTION
Préparation à la **mise en ligne** : corrige des manques concrets qui se voient au lancement.

## Corrections

**`index.html`**
- **Open Graph + Twitter Card** : un lien partagé sur LinkedIn / WhatsApp / Slack affiche désormais un aperçu (titre, description, image) au lieu d'un lien nu — important pour du B2B.
- **Lien canonique** + `og:locale fr_FR`.
- **Icônes corrigées** : `favicon.ico` + PNG 16/32, `apple-touch-icon`, `manifest` lié. (L'ancienne balise déclarait `type="image/svg+xml"` en pointant un `.ico` — incohérent.)
- **`theme-color`** noir → bleu marine PEG `#0f1c2e`.

**`public/manifest.json`**
- Remplace le **placeholder Create React App** (`"React App"` / `"Create React App Sample"`, icônes `logo192.png` **inexistantes**) par l'identité MyPEG et les vraies icônes (`android-chrome-*`).

**`public/site.webmanifest`**
- `name` / `short_name` étaient **vides** → renseignés ; thème aligné.

## Garde-fous

- **Aucun changement de libellé métier** : titre et description réutilisés tels quels (terminologie protégée respectée).
- **CSP inchangé.**

## Vérifications

- `npx jest src/__tests__/terminology-guard.test.ts` → 39/39 ✅
- `npx jest` → **192 tests verts** ✅
- `npm run build` ✅ (balises OG présentes dans `build/index.html`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3mL15pLpBeRsL73HKmc6H)_