### PR TITLE
fix(ux): repli d'erreur vers l'accueil (tous rôles) + tests ErrorBoundary

### DIFF
--- a/src/__tests__/ErrorBoundary.test.tsx
+++ b/src/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests — ErrorBoundary (composant critique pour le lancement).
+ *
+ * Rôle : empêcher l'écran blanc si un composant plante en prod. On vérifie
+ * qu'un enfant qui lève une erreur déclenche le repli (fallback) au lieu de
+ * casser toute l'app, que les enfants sains s'affichent normalement, et que
+ * le bouton de repli renvoie vers l'accueil (route valable pour TOUS les
+ * rôles — un client ne doit pas être envoyé vers /admin).
+ */
+
+import * as React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot, Root } from 'react-dom/client';
+import ErrorBoundary from '@/components/ErrorBoundary';
+
+const Boom = (): JSX.Element => {
+  throw new Error('boom test');
+};
+
+let container: HTMLDivElement;
+let root: Root;
+let consoleErr: jest.SpyInstance;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  // React journalise l'erreur attrapée ; on la masque pour garder la sortie propre.
+  consoleErr = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  consoleErr.mockRestore();
+});
+
+describe('ErrorBoundary', () => {
+  test('affiche les enfants quand tout va bien', () => {
+    act(() => {
+      root.render(
+        <ErrorBoundary>
+          <p>Contenu OK</p>
+        </ErrorBoundary>
+      );
+    });
+    expect(container.textContent).toContain('Contenu OK');
+    expect(container.textContent).not.toContain('Une erreur est survenue');
+  });
+
+  test('affiche le repli quand un enfant plante (pas d\'écran blanc)', () => {
+    act(() => {
+      root.render(
+        <ErrorBoundary>
+          <Boom />
+        </ErrorBoundary>
+      );
+    });
+    expect(container.textContent).toContain('Une erreur est survenue');
+  });
+
+  test('le repli propose un retour à l\'accueil (route valable tous rôles)', () => {
+    act(() => {
+      root.render(
+        <ErrorBoundary>
+          <Boom />
+        </ErrorBoundary>
+      );
+    });
+    const labels = Array.from(container.querySelectorAll('button')).map((b) => b.textContent);
+    expect(labels).toContain("Retour à l'accueil");
+    // ne doit PAS renvoyer vers une route admin (inaccessible aux clients)
+    expect(container.innerHTML).not.toContain('/admin/dashboard');
+  });
+
+  test('utilise un fallback personnalisé si fourni', () => {
+    act(() => {
+      root.render(
+        <ErrorBoundary fallback={<div>Repli maison</div>}>
+          <Boom />
+        </ErrorBoundary>
+      );
+    });
+    expect(container.textContent).toContain('Repli maison');
+    expect(container.textContent).not.toContain('Une erreur est survenue');
+  });
+});

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -63,10 +63,10 @@ class ErrorBoundary extends Component<Props, State> {
             )}
             <div className="flex gap-3 justify-center">
               <button
-                onClick={() => { window.location.href = '/admin/dashboard' }}
+                onClick={() => { window.location.href = '/' }}
                 className="px-4 py-2 bg-white/10 text-white rounded-lg hover:bg-white/15 transition text-sm"
               >
-                Retour au dashboard
+                Retour à l'accueil
               </button>
               <button
                 onClick={() => window.location.reload()}


### PR DESCRIPTION
Suite de la préparation au lancement — corrige un **bug d'écran d'erreur** et ajoute le premier test de composant.

## Bug corrigé

En cas de crash d'un composant, l'`ErrorBoundary` affiche un écran de repli avec un bouton. Ce bouton envoyait vers **`/admin/dashboard`** — une route **inaccessible à un client ou un producteur**. Un utilisateur non-admin tombant sur une erreur se retrouvait donc bloqué sur une page interdite.

→ Redirigé vers l'**accueil (`/`)**, route valable pour **tous les rôles** (le routage post-login envoie chacun vers son bon tableau de bord).

## Nouveaux tests (4) — `ErrorBoundary.test.tsx`

Premier **test de composant React** du projet (rendu client via jsdom, désormais disponible) :
- affiche les enfants quand tout va bien
- affiche le repli en cas de crash (**pas d'écran blanc**)
- le bouton renvoie vers l'accueil, **jamais** vers `/admin/dashboard`
- respecte un `fallback` personnalisé

## Vérifications

- `npx tsc --noEmit` ✅
- `npx jest` → **196 tests verts** (192 + 4 nouveaux) ✅
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3mL15pLpBeRsL73HKmc6H)_