### PR TITLE
fix(ux): supprime 3 causes de page blanche (audit multi-agents)

### DIFF
--- a/src/components/route/AuthorityGuard.tsx
+++ b/src/components/route/AuthorityGuard.tsx
@@ -12,7 +12,9 @@ const AuthorityGuard = (props: AuthorityGuardProps) => {
 
     const roleMatched = useAuthority(userAuthority, authority)
 
-    return <>{roleMatched ? children : <Navigate to="/access-denied" />}</>
+    // Accès refusé : on renvoie vers l'accueil (route réelle, résolue par rôle)
+    // plutôt que vers "/access-denied" qui n'existe pas (rebond silencieux).
+    return <>{roleMatched ? children : <Navigate to="/home" replace />}</>
 }
 
 export default AuthorityGuard

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -17,11 +17,32 @@ import { Suspense } from 'react'
 const Home = () => {
   const { user }: { user: User } = useAppSelector((state) => state.auth.user)
 
+  const isAdmin = hasRole(user, [SUPER_ADMIN, ADMIN])
+  const isCustomer = hasRole(user, [CUSTOMER])
+  const isProducer = hasRole(user, [PRODUCER])
+  const isKnownRole = isAdmin || isCustomer || isProducer
+
   return (
     <Suspense fallback={null}>
-      {hasRole(user, [SUPER_ADMIN, ADMIN]) && <DashboardAdmin />}
-      {hasRole(user, [CUSTOMER]) && <DashboardCustomer />}
-      {hasRole(user, [PRODUCER]) && <DashboardProducer />}
+      {isAdmin && <DashboardAdmin />}
+      {isCustomer && <DashboardCustomer />}
+      {isProducer && <DashboardProducer />}
+      {/* Repli : rôle inconnu/non configuré → message plutôt qu'une page blanche */}
+      {!isKnownRole && (
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          minHeight: '60vh', flexDirection: 'column', gap: '12px',
+          fontFamily: 'Inter, sans-serif', textAlign: 'center', padding: '24px',
+        }}>
+          <p style={{ color: 'rgba(255,255,255,0.6)', fontSize: '16px', fontWeight: 600, margin: 0 }}>
+            Bienvenue, {user?.firstName || user?.email || ''} 👋
+          </p>
+          <p style={{ color: 'rgba(255,255,255,0.35)', fontSize: '13px', margin: 0, maxWidth: '360px' }}>
+            Votre compte est en cours de configuration. Si le problème persiste,
+            contactez votre administrateur.
+          </p>
+        </div>
+      )}
     </Suspense>
   )
 }

--- a/src/views/app/producer/home/DashboardProducer.tsx
+++ b/src/views/app/producer/home/DashboardProducer.tsx
@@ -89,7 +89,7 @@ const stateLabels: Record<string, { label: string; color: string; bg: string; bo
 const DashboardProducer = () => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
-  const { producer } = useAppSelector((state) => state.dashboardProducer.data);
+  const { producer, loading } = useAppSelector((state) => state.dashboardProducer.data);
   const { user }: { user: User } = useSelector(
     (state: RootState) => state.auth.user
   );
@@ -117,8 +117,36 @@ const DashboardProducer = () => {
   const projectsInProgress = producer?.projects?.filter((p) => p.state !== 'fulfilled' && p.state !== 'canceled').length ?? 0;
   const activeProjects = producer?.projects?.filter((p) => p.state !== 'fulfilled' && p.state !== 'canceled') ?? [];
 
+  // État de chargement (évite l'écran blanc pendant le fetch producteur)
+  if (loading) {
+    return (
+      <div style={{ padding: '32px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} style={{ height: '80px', borderRadius: '16px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.06)', animation: 'pulse 1.5s ease-in-out infinite' }} />
+        ))}
+      </div>
+    );
+  }
+
+  // Producteur absent (relation manquante ou fetch en échec) : message plutôt
+  // qu'une page blanche.
+  if (!producer) {
+    return (
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        minHeight: '60vh', flexDirection: 'column', gap: '12px', fontFamily: 'Inter, sans-serif',
+      }}>
+        <p style={{ color: 'rgba(255,255,255,0.5)', fontSize: '15px' }}>
+          Bienvenue, {user?.firstName || user?.email} 👋
+        </p>
+        <p style={{ color: 'rgba(255,255,255,0.25)', fontSize: '13px' }}>
+          Votre espace producteur est en cours de configuration. Revenez dans quelques instants.
+        </p>
+      </div>
+    );
+  }
+
   return (
-    producer && (
       <Suspense fallback={<></>}>
         {/* Banner */}
         <div style={{ position: 'relative' }}>
@@ -288,7 +316,6 @@ const DashboardProducer = () => {
           </div>
         </Container>
       </Suspense>
-    )
   );
 };
 


### PR DESCRIPTION
Suite de l'audit multi-agents — élimine les **écrans blancs** repérés (robustesse pour le lancement).

## 1. Dashboard producteur — plus d'écran blanc

`DashboardProducer` rendait `null` tant que `producer` était falsy — c'est-à-dire **pendant le chargement**, si la relation producteur est absente, ou si le fetch échoue (les 500 REST connus en prod). Le producteur voyait un `/home` totalement blanc.

→ Ajout d'un **état de chargement** (skeleton) et d'un **état vide/erreur** (message de bienvenue), sur le modèle de `DashboardCustomer`.

## 2. Home — repli pour les rôles inconnus

`Home` ne rendait un dashboard que pour admin/customer/producer. Or `/home` autorise aussi `USER`/`publisher`. Un compte à l'un de ces rôles (ou mal configuré) → page vide après login.

→ Repli avec message quand aucun rôle connu ne matche.

## 3. AuthorityGuard — fin de la route fantôme

En cas d'accès refusé, redirection vers **`/access-denied`** — route **inexistante** → rebond silencieux via le catch-all `*` → `/`. Analogue structurel du bug ErrorBoundary corrigé précédemment.

→ Redirigé vers **`/home`** (route réelle, résolue selon le rôle).

## Vérifications
- `npx tsc --noEmit` ✅
- `npx jest` → **196 tests verts** ✅
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3mL15pLpBeRsL73HKmc6H)_