### PR TITLE
test: reducers notifications + planificateur (audit multi-agents)

### DIFF
--- a/src/__tests__/notificationSlice.test.ts
+++ b/src/__tests__/notificationSlice.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests unitaires — reducer notifications (notificationSlice).
+ *
+ * CLAUDE.md signale la classe de bug « notifications perdues/dupliquées ».
+ * On verrouille ici : dédoublonnage par `_id`, intégrité du compteur de
+ * non-lus (jamais négatif, jamais décrémenté deux fois), pagination.
+ *
+ * Reducer pur → testé via reducer(state, action), sans mock.
+ */
+
+import reducer, {
+  setUnreadCount,
+  setNotifications,
+  appendNotifications,
+  addNotification,
+  markAsRead,
+  markAllAsRead,
+  removeNotification,
+  removeAllNotifications,
+  setConnectionStatus,
+  NotificationItem,
+  NotificationState,
+} from '@/store/slices/base/notificationSlice';
+
+// État initial obtenu via le reducer lui-même (initialState non exporté).
+const init = (): NotificationState => reducer(undefined, { type: '@@INIT' } as any);
+
+const notif = (id: string, read = false): NotificationItem =>
+  ({
+    _id: id,
+    eventType: 'new_order',
+    title: `t-${id}`,
+    message: `m-${id}`,
+    link: '',
+    read,
+    metadata: {},
+    createdAt: '2026-01-01T00:00:00Z',
+  });
+
+describe('addNotification', () => {
+  test('ajoute en tête et incrémente les non-lus', () => {
+    let s = init();
+    s = reducer(s, addNotification(notif('a')));
+    expect(s.notifications.map((n) => n._id)).toEqual(['a']);
+    expect(s.unreadCount).toBe(1);
+    s = reducer(s, addNotification(notif('b')));
+    expect(s.notifications.map((n) => n._id)).toEqual(['b', 'a']); // unshift
+    expect(s.unreadCount).toBe(2);
+  });
+
+  test('doublon par _id → aucun ajout, aucun incrément', () => {
+    let s = reducer(init(), addNotification(notif('a')));
+    s = reducer(s, addNotification(notif('a')));
+    expect(s.notifications).toHaveLength(1);
+    expect(s.unreadCount).toBe(1);
+  });
+
+  test('notification déjà lue → n\'incrémente pas les non-lus', () => {
+    const s = reducer(init(), addNotification(notif('a', true)));
+    expect(s.notifications).toHaveLength(1);
+    expect(s.unreadCount).toBe(0);
+  });
+});
+
+describe('markAsRead — pas de double décrément', () => {
+  test('marque lu et décrémente une fois', () => {
+    let s = reducer(init(), addNotification(notif('a')));
+    s = reducer(s, markAsRead('a'));
+    expect(s.notifications[0].read).toBe(true);
+    expect(s.unreadCount).toBe(0);
+  });
+
+  test('re-marquer une notif déjà lue ne décrémente pas', () => {
+    let s = reducer(init(), addNotification(notif('a')));
+    s = reducer(s, markAsRead('a'));
+    s = reducer(s, markAsRead('a'));
+    expect(s.unreadCount).toBe(0); // pas passé en négatif
+  });
+
+  test('id inconnu → aucun effet', () => {
+    const s0 = reducer(init(), addNotification(notif('a')));
+    const s1 = reducer(s0, markAsRead('zzz'));
+    expect(s1.unreadCount).toBe(1);
+  });
+});
+
+describe('markAllAsRead', () => {
+  test('passe tout en lu et met le compteur à zéro', () => {
+    let s = reducer(init(), addNotification(notif('a')));
+    s = reducer(s, addNotification(notif('b')));
+    s = reducer(s, markAllAsRead());
+    expect(s.notifications.every((n) => n.read)).toBe(true);
+    expect(s.unreadCount).toBe(0);
+  });
+});
+
+describe('removeNotification', () => {
+  test('supprime une non-lue → décrémente', () => {
+    let s = reducer(init(), addNotification(notif('a')));
+    s = reducer(s, addNotification(notif('b')));
+    s = reducer(s, removeNotification('a'));
+    expect(s.notifications.map((n) => n._id)).toEqual(['b']);
+    expect(s.unreadCount).toBe(1);
+  });
+
+  test('supprime une lue → ne décrémente pas', () => {
+    let s = reducer(init(), addNotification(notif('a', true)));
+    s = reducer(s, removeNotification('a'));
+    expect(s.notifications).toHaveLength(0);
+    expect(s.unreadCount).toBe(0);
+  });
+
+  test('id inconnu → aucun effet', () => {
+    const s0 = reducer(init(), addNotification(notif('a')));
+    const s1 = reducer(s0, removeNotification('zzz'));
+    expect(s1.notifications).toHaveLength(1);
+    expect(s1.unreadCount).toBe(1);
+  });
+});
+
+describe('appendNotifications — pagination + dédup', () => {
+  test('n\'ajoute que les nouveaux _id, incrémente la page', () => {
+    let s = reducer(init(), setNotifications([notif('a'), notif('b')]));
+    expect(s.page).toBe(1);
+    s = reducer(
+      s,
+      appendNotifications({ notifications: [notif('b'), notif('c')], hasMore: false })
+    );
+    expect(s.notifications.map((n) => n._id)).toEqual(['a', 'b', 'c']); // b non dupliqué
+    expect(s.hasMore).toBe(false);
+    expect(s.page).toBe(2);
+  });
+});
+
+describe('setters divers', () => {
+  test('setNotifications remplace et réinitialise la page', () => {
+    let s = reducer(init(), appendNotifications({ notifications: [notif('a')], hasMore: true }));
+    s = reducer(s, setNotifications([notif('x')]));
+    expect(s.notifications.map((n) => n._id)).toEqual(['x']);
+    expect(s.page).toBe(1);
+  });
+
+  test('setUnreadCount force la valeur', () => {
+    expect(reducer(init(), setUnreadCount(7)).unreadCount).toBe(7);
+  });
+
+  test('removeAllNotifications vide tout', () => {
+    let s = reducer(init(), addNotification(notif('a')));
+    s = reducer(s, removeAllNotifications());
+    expect(s.notifications).toHaveLength(0);
+    expect(s.unreadCount).toBe(0);
+    expect(s.hasMore).toBe(false);
+    expect(s.page).toBe(1);
+  });
+
+  test('setConnectionStatus met à jour le statut', () => {
+    expect(reducer(init(), setConnectionStatus('polling')).connectionStatus).toBe('polling');
+  });
+});

--- a/src/__tests__/scheduler.test.ts
+++ b/src/__tests__/scheduler.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests unitaires — planificateur (utils/planning/scheduler.ts).
+ *
+ * Socle du planning admin : un bug de comptage de jours ouvrés ou de calcul
+ * de risque fausse les marges, l'urgence et les deadlines affichées. Fonctions
+ * pures → dates construites en local (new Date(y, m, d)) pour éviter les
+ * décalages de fuseau.
+ */
+
+import {
+  businessDaysBetween,
+  nextBusinessDays,
+  analyzeProjects,
+  countRisks,
+  riskScore,
+  isoWeekNumber,
+  currentWeekDays,
+} from '@/utils/planning/scheduler';
+import { Project } from '@/@types/project';
+
+// 2024-01-01 est un lundi ; 01-05 vendredi ; 01-06 samedi ; 01-08 lundi.
+const d = (y: number, m: number, day: number) => new Date(y, m, day);
+
+describe('businessDaysBetween', () => {
+  test('lundi → vendredi = 4 jours ouvrés', () => {
+    expect(businessDaysBetween(d(2024, 0, 1), d(2024, 0, 5))).toBe(4);
+  });
+
+  test('vendredi → lundi = 1 (week-end sauté)', () => {
+    expect(businessDaysBetween(d(2024, 0, 5), d(2024, 0, 8))).toBe(1);
+  });
+
+  test('même jour = 0', () => {
+    expect(businessDaysBetween(d(2024, 0, 3), d(2024, 0, 3))).toBe(0);
+  });
+
+  test('deadline dépassée → valeur négative', () => {
+    expect(businessDaysBetween(d(2024, 0, 5), d(2024, 0, 1))).toBe(-4);
+  });
+});
+
+describe('nextBusinessDays', () => {
+  test('depuis un samedi → démarre le lundi suivant, que des jours ouvrés', () => {
+    const days = nextBusinessDays(3, d(2024, 0, 6)); // samedi
+    expect(days).toHaveLength(3);
+    expect(days.every((dd) => dd.getDay() >= 1 && dd.getDay() <= 5)).toBe(true);
+    expect(days[0].getDate()).toBe(8); // lundi 8 janvier
+    expect(days[0].getMonth()).toBe(0);
+  });
+});
+
+describe('analyzeProjects — priorisation par urgence', () => {
+  const today = d(2024, 0, 15); // lundi
+  const mk = (over: Partial<Project>): Project =>
+    ({ documentId: 'x', state: 'pending', price: 100, priority: 'medium', ...over } as unknown as Project);
+
+  const projects: Project[] = [
+    mk({ documentId: 'p1', endDate: d(2024, 0, 10), priority: 'high', price: 1000 }), // en retard
+    mk({ documentId: 'p2', endDate: d(2024, 1, 15), priority: 'low', price: 100 }), // confortable
+    mk({ documentId: 'p3', state: 'fulfilled', endDate: d(2024, 0, 20) }), // exclu (statut)
+    mk({ documentId: 'p4', endDate: undefined }), // exclu (pas de deadline)
+  ];
+
+  const result = analyzeProjects(projects, today, { p1: 1, p2: 1 });
+
+  test('ignore les projets hors statut actif ou sans deadline', () => {
+    expect(result.map((r) => r.project.documentId).sort()).toEqual(['p1', 'p2']);
+  });
+
+  test('le projet en retard est classé "late" et en tête', () => {
+    expect(result[0].project.documentId).toBe('p1');
+    expect(result[0].risk).toBe('late');
+  });
+
+  test('le projet confortable est "ok"', () => {
+    const p2 = result.find((r) => r.project.documentId === 'p2');
+    expect(p2?.risk).toBe('ok');
+  });
+});
+
+describe('countRisks', () => {
+  test('agrège les niveaux de risque', () => {
+    const scheduled = [
+      { risk: 'late' }, { risk: 'tight' }, { risk: 'ok' }, { risk: 'late' },
+    ] as any;
+    expect(countRisks(scheduled)).toEqual({ late: 2, tight: 1, ok: 1, total: 4 });
+  });
+});
+
+describe('riskScore — borné [2, 98]', () => {
+  test('marge nulle → 50', () => {
+    expect(riskScore({ margin: 0 } as any)).toBe(50);
+  });
+  test('grosse marge positive → plafonné à 98', () => {
+    expect(riskScore({ margin: 20 } as any)).toBe(98);
+  });
+  test('grosse marge négative → plancher à 2', () => {
+    expect(riskScore({ margin: -20 } as any)).toBe(2);
+  });
+});
+
+describe('isoWeekNumber / currentWeekDays', () => {
+  test('le 4 janvier est toujours en semaine ISO 1', () => {
+    expect(isoWeekNumber(d(2024, 0, 4))).toBe(1);
+  });
+
+  test('currentWeekDays renvoie 7 jours démarrant un lundi', () => {
+    const week = currentWeekDays(d(2024, 0, 3)); // mercredi
+    expect(week).toHaveLength(7);
+    expect(week[0].getDay()).toBe(1); // lundi
+    expect(week[0].getDate()).toBe(1); // lundi 1er janvier
+  });
+});


### PR DESCRIPTION
Dernier lot de l'audit multi-agents : tests sur deux modules de logique métier à fort risque, recommandés par l'agent d'analyse.

## `notificationSlice` (15 tests)

Verrouille la classe de bug **« notifications perdues / dupliquées »** documentée dans `CLAUDE.md` :
- **dédoublonnage par `_id`** (`addNotification`, `appendNotifications`)
- **`unreadCount`** jamais négatif, jamais décrémenté deux fois (`markAsRead`, `removeNotification`)
- `markAllAsRead`, `removeAllNotifications`, pagination (`page`), setters

## `planning/scheduler` (14 tests)

Socle du planning admin — un bug fausse marges, urgence et deadlines :
- **`businessDaysBetween`** : week-ends sautés, `0` le même jour, **négatif** si deadline dépassée
- **`nextBusinessDays`** : démarre le bon jour ouvré
- **`analyzeProjects`** : exclut les projets hors statut actif / sans deadline, **trie par urgence**, niveau de risque (`late`/`ok`)
- **`countRisks`**, **`riskScore`** (borné `[2, 98]`), **`isoWeekNumber`**, **`currentWeekDays`**

## Vérifications
- `npx tsc --noEmit` ✅
- `npx jest` → **225 tests verts** (196 + 29 nouveaux) ✅
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3mL15pLpBeRsL73HKmc6H)_