### PR TITLE
fix(panier): re-valide le code promo quand le sous-total change

### DIFF
--- a/src/views/app/customer/cart/PaymentContent.tsx
+++ b/src/views/app/customer/cart/PaymentContent.tsx
@@ -4,7 +4,7 @@ import {
   applyPremiumDiscount,
 } from '@/utils/productHelpers';
 import { Checkout, ShippingAddress } from '@/@types/checkout';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { loadStripe } from '@stripe/stripe-js';
 import { env } from '@/configs/env.config';
 import { API_BASE_URL } from '@/configs/api.config';
@@ -80,6 +80,28 @@ function PaymentContent({ cart, shipping, hasAddress, onMissingAddress }: { cart
     setAppliedCode('');
     setPromoInput('');
   };
+
+  // Le sous-total peut changer APRÈS l'application d'un code (article retiré du
+  // panier sur la même page, PaymentContent restant monté). On re-valide alors
+  // le code appliqué pour garder la remise AFFICHÉE cohérente : recalcul du
+  // pourcentage sur le nouveau sous-total, ou invalidation si le montant minimum
+  // n'est plus atteint. (Le montant réellement débité est de toute façon
+  // recalculé côté backend ; ceci corrige uniquement l'affichage.)
+  useEffect(() => {
+    if (!appliedCode) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await apiValidatePromoCode(appliedCode, subtotalHT);
+        if (!cancelled) setPromoValidation(result);
+      } catch {
+        if (!cancelled) setPromoValidation({ valid: false, reason: 'Erreur de validation' });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [subtotalHT, appliedCode]);
 
   const createFormAnswer = async (
     item: CartItem


### PR DESCRIPTION
Corrige le dernier finding de l'audit : la **remise promo affichée** pouvait être périmée.

## Le problème

`apiValidatePromoCode(code, subtotalHT)` était appelé au clic « Appliquer », et `discountAmount` figé. Si le client **retirait ensuite un article** du panier (colonne de gauche, sans quitter la page), `PaymentContent` restait monté et la remise n'était pas recalculée.

**Scénario** : sous-total 500 € HT, code −10 % → remise 50 €. Le client supprime un article → sous-total 200 €, mais la remise reste 50 € (soit 25 % effectifs au lieu de 10 %). Un montant minimum de commande déjà validé pouvait aussi ne plus être respecté.

## Le correctif

`useEffect` qui **re-valide le code appliqué à chaque changement de sous-total** : recalcul du pourcentage sur le nouveau sous-total, ou invalidation si le minimum n'est plus atteint. Guard `cancelled` contre les races.

> À noter : le **montant réellement débité était déjà correct** — le backend `recalculateFromDB` recalcule la promo côté serveur. Ce correctif rétablit uniquement la **cohérence de l'affichage** vu par le client.

## Vérifications
- `npx tsc --noEmit` ✅
- `npx jest` → **225 tests verts** ✅
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3mL15pLpBeRsL73HKmc6H)_