### PR TITLE
fix(produits): le mode Packs/m² s'enregistre en production

### DIFF
--- a/src/views/app/admin/products/product/EditProduct.tsx
+++ b/src/views/app/admin/products/product/EditProduct.tsx
@@ -336,22 +336,26 @@ const EditProduct = () => {
       // id numérique → toujours écarté ici (gestion propre à traiter à part).
       delete data.batFile;
       // Ne transmettre que les champs réellement acceptés par le backend
-      // DÉPLOYÉ. La prod Strapi (Heroku) étant déployée à la main, elle peut
-      // être en retard sur le schéma `main` : envoyer un champ inexistant
-      // (pricingMode, pricePerM2, minM2, catalogPrice, requiresBat, suggested…)
-      // renverrait un 400 qui ferait échouer TOUT l'enregistrement. On filtre
-      // donc sur l'introspection de ProductInput.
+      // DÉPLOYÉ (introspection de ProductInput) : un champ inexistant → 400 qui
+      // ferait échouer TOUT l'enregistrement.
       const inputFields = await apiGetProductInputFields();
       if (inputFields) {
         Object.keys(data).forEach((k) => {
           if (k !== 'documentId' && !inputFields.has(k)) delete data[k];
         });
       } else {
-        // Introspection indisponible → repli conservateur (comportement
-        // historique : on écarte les champs potentiellement non déployés).
-        ['requiresBat', 'catalogPrice', 'pricingMode', 'pricePerM2', 'minM2', 'suggested'].forEach(
-          (k) => delete data[k]
-        );
+        // Introspection indisponible — cas NORMAL en production : Strapi v5
+        // (Apollo Server 4) désactive l'introspection quand NODE_ENV=production.
+        // L'ancien repli supprimait pricingMode/pricePerM2/minM2/catalogPrice/
+        // requiresBat/suggested → en prod, choisir « Packs » ne s'enregistrait
+        // JAMAIS (perte silencieuse). Ces champs sont déployés sur la prod
+        // (schéma main) : on les transmet donc. Si un jour le backend est en
+        // retard, l'erreur 400 sera VISIBLE (toast) au lieu d'une perte muette.
+        //
+        // Seule exception : `suggested`. Sans introspection, sa valeur initiale
+        // n'a pas pu être lue (probe __type indisponible) — l'envoyer écraserait
+        // une curation existante avec le défaut du formulaire.
+        if (!suggestedAvailable) delete data.suggested;
       }
 
       await updateOrCreateProduct(data);


### PR DESCRIPTION
Corrige le bug signalé : **choisir « Packs » dans la config produit restait « Prix dégressifs » après enregistrement** — en production uniquement.

## Cause racine

Strapi v5 s'appuie sur **Apollo Server 4, qui désactive l'introspection GraphQL quand `NODE_ENV=production`** (aucune config `graphql` dans `plugins.ts` du backend pour la réactiver). En prod :

1. `apiGetProductInputFields()` (introspection de `ProductInput`) échoue → renvoie `null`
2. Le repli « conservateur » de `EditProduct.tsx` supprimait alors **silencieusement** `pricingMode`, `pricePerM2`, `minM2`, `catalogPrice`, `requiresBat`, `suggested` du payload
3. → ces champs n'étaient **jamais enregistrés** depuis la prod (le mode retombait sur `tiers`)

Ce repli datait de l'époque où la prod Heroku était en retard de schéma. Or la prod tourne désormais sur `main`, qui possède tous ces champs (`schema.json` vérifié).

## Correctif

- Introspection disponible (dev) → filtrage inchangé.
- Introspection indisponible (prod) → **on transmet les champs** ; si un jour le backend est en retard, le 400 sera **visible** (toast) au lieu d'une perte muette de données.
- Exception : `suggested` reste écarté si sa valeur initiale n'a pas pu être lue (même introspection) — pour ne pas écraser une curation existante avec le défaut du formulaire.

## Amélioration durable possible (backend, optionnelle)

Réactiver l'introspection en prod via `config/plugins.ts` de `peg_strapi` (`graphql.config.apolloServer.introspection: true`) — redonnerait au front son filtrage précis + le probe `suggested`. Nécessite un déploiement Heroku manuel.

## Vérifications
- `npx tsc --noEmit` ✅ · `npx jest` → **225 tests verts** ✅ · `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3mL15pLpBeRsL73HKmc6H)_