### PR TITLE
feat(produits): réactiver catalogPrice/requiresBat/checklist (backend aligné)

### DIFF
--- a/src/services/ProductServices.ts
+++ b/src/services/ProductServices.ts
@@ -87,10 +87,13 @@ export async function apiGetProductForEditById(documentId: string): Promise<Axio
                 documentId
                 fields
             }
-            # checklist { documentId name items }  — activer après déploiement Strapi
-            # requiresBat                          — activer après déploiement Strapi
-            # batFile { documentId url name }      — activer après déploiement Strapi
-            # catalogPrice                         — activer après déploiement Strapi
+            checklist {
+                documentId
+            }
+            requiresBat
+            catalogPrice
+            # batFile { documentId url name }      — laissé désactivé : le média
+            #   renvoie un documentId là où l'update attend un id numérique
             productRef
             refVisibleToCustomer
             customerCategories {

--- a/src/views/app/admin/products/product/EditProduct.tsx
+++ b/src/views/app/admin/products/product/EditProduct.tsx
@@ -335,21 +335,13 @@ const EditProduct = () => {
       // `batFile` (média) : le code produit un documentId là où Strapi attend un
       // id numérique → toujours écarté ici (gestion propre à traiter à part).
       delete data.batFile;
-      // Champs CŒUR du schéma produit CONFIRMÉS présents sur le backend déployé :
-      // la requête de lecture (apiGetProductForEditById) les renvoie sans erreur.
-      // On ne les retire JAMAIS du payload — c'est LE correctif du bug « Packs
-      // ne s'enregistre pas » (pricingMode était stripé silencieusement).
+      // Champs CŒUR du schéma produit (backend prod désormais aligné sur `main`) :
+      // jamais retirés du payload. C'est le correctif du bug « Packs/m² ne
+      // s'enregistre pas » — pricingMode & consorts étaient stripés silencieusement.
       const ALWAYS_KEEP = new Set([
         'pricingMode', 'pricePerM2', 'minM2', 'cost', 'priceTiers', 'price',
+        'catalogPrice', 'requiresBat',
       ]);
-
-      // Champs dont la présence sur le backend DÉPLOYÉ n'est PAS garantie : ils
-      // ne figurent pas dans la requête de lecture, donc le Heroku de prod
-      // (déployé à la main, possiblement en retard sur `main`) peut ne pas les
-      // exposer. Les envoyer déclenche un 400 qui fait échouer TOUT
-      // l'enregistrement (y compris pricingMode). On les écarte donc quand on ne
-      // peut PAS vérifier leur existence via introspection.
-      const UNCONFIRMED = ['catalogPrice', 'requiresBat', 'suggested'];
 
       const inputFields = await apiGetProductInputFields();
       if (inputFields) {
@@ -359,11 +351,12 @@ const EditProduct = () => {
             delete data[k];
           }
         });
-      } else {
-        // Introspection indisponible (prod) : on écarte les champs non confirmés
-        // pour éviter le 400. Les champs cœur (pricingMode…) restent transmis.
-        UNCONFIRMED.forEach((k) => delete data[k]);
       }
+      // `suggested` n'existe PAS dans le schéma product Strapi (la curation se
+      // gère via l'onglet Suggestions, mutation dédiée). L'envoyer via le
+      // formulaire produit déclencherait un 400 ; on ne le transmet donc que si
+      // l'introspection confirme explicitement sa présence.
+      if (!suggestedAvailable) delete data.suggested;
 
       await updateOrCreateProduct(data);
       navigate('/admin/products');


### PR DESCRIPTION
Le backend prod (`peg_strapi` `main`) vient d'être déployé sur Heroku → tous les champs du schéma produit existent désormais. On **retire le contournement #215** qui écartait des champs par précaution.

## Changements

**Lecture** (`apiGetProductForEditById`) : réactive `requiresBat`, `catalogPrice` et `checklist` (ils étaient commentés « à activer après déploiement Strapi ») → le formulaire d'édition **affiche à nouveau leurs valeurs enregistrées** (avant, ils revenaient toujours au défaut).

**Sauvegarde** (`EditProduct.tsx`) : `catalogPrice` et `requiresBat` rejoignent `ALWAYS_KEEP` → ils **s'enregistrent de nouveau depuis la prod**, sans provoquer le 400.

**Conservé :**
- `suggested` reste écarté — **absent du schéma** `product` Strapi (la curation se gère via l'onglet Suggestions, mutation dédiée).
- `batFile` laissé désactivé (média : `documentId` vs id numérique — à traiter séparément).
- `pricingMode` (le bug d'origine) : toujours transmis. ✅

## Vérifications
- `npx tsc --noEmit` ✅ · `npx jest` → **225 tests verts** ✅ · `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3mL15pLpBeRsL73HKmc6H)_