### PR TITLE
style(catalogue): harmoniser les photos produit (admin + client)

### DIFF
--- a/src/views/app/admin/products/categories/AdminProductsOfCategory.tsx
+++ b/src/views/app/admin/products/categories/AdminProductsOfCategory.tsx
@@ -65,11 +65,18 @@ const AdminProductsOfCategory = () => {
                   <img
                     src={product.images?.[0]?.url ?? '/img/others/img-2.png'}
                     alt={product.name}
-                    className=" rounded-lg bg-slate-50"
+                    className="rounded-lg"
                     style={{
-                      height: '250px',
+                      height: '220px',
                       width: '100%',
-                      objectFit: 'cover',
+                      // `contain` + padding : l'image entière tient dans le cadre
+                      // (jamais rognée ni débordante), cohérent avec la carte
+                      // produit admin. `cover` agrandissait/coupait les visuels.
+                      objectFit: 'contain',
+                      padding: '12px',
+                      boxSizing: 'border-box',
+                      background: '#fff',
+                      display: 'block',
                     }}
                   />
                   <div className="flex flex-col justify-between">

--- a/src/views/app/customer/products/lists/CustomerProductCard.tsx
+++ b/src/views/app/customer/products/lists/CustomerProductCard.tsx
@@ -40,7 +40,7 @@ const CustomerProductCard = ({ product }: { product: Product }) => {
       cardRef.current.style.boxShadow = '0 24px 48px rgba(0,0,0,0.5), 0 0 0 1px rgba(47,111,237,0.25)';
     }
     if (imgRef.current) {
-      imgRef.current.style.transform = 'scale(1.0)';
+      imgRef.current.style.transform = 'scale(1.05)';
     }
   };
 
@@ -50,7 +50,7 @@ const CustomerProductCard = ({ product }: { product: Product }) => {
       cardRef.current.style.boxShadow = '0 4px 20px rgba(0,0,0,0.3), 0 0 0 1px rgba(255,255,255,0.06)';
     }
     if (imgRef.current) {
-      imgRef.current.style.transform = 'scale(0.94)';
+      imgRef.current.style.transform = 'scale(1)';
     }
   };
 
@@ -84,9 +84,14 @@ const CustomerProductCard = ({ product }: { product: Product }) => {
             style={{
               width: '100%',
               height: '100%',
-              objectFit: 'cover',
+              // `contain` + padding : le produit entier tient dans le cadre,
+              // centré, jamais rogné/débordant. `cover` agrandissait et coupait
+              // les visuels (ils « sortaient du cadre »).
+              objectFit: 'contain',
+              padding: '16px',
+              boxSizing: 'border-box',
               display: 'block',
-              transform: 'scale(0.94)',
+              transform: 'scale(1)',
               transition: 'transform 0.35s ease',
             }}
           />


### PR DESCRIPTION
Les vignettes produit débordaient / étaient rognées (« sortaient du cadre »), **côté admin ET côté client**.

## Cause
`objectFit: cover` (+ `scale(0.94)` côté client) → l'image était agrandie pour remplir la vignette puis **rognée**, donnant l'impression qu'elle sortait du cadre. Incohérent d'un écran à l'autre.

## Correctif (mêmes règles partout)
`objectFit: contain` + `padding` : le **visuel entier** tient dans le cadre, centré, **jamais rogné ni débordant**.

| Écran | Fichier |
|-------|---------|
| **Admin** — Produits d'une catégorie | `AdminProductsOfCategory.tsx` (`cover` → `contain` + padding + fond blanc) |
| **Client** — cartes du catalogue | `CustomerProductCard.tsx` (`cover`+`scale(0.94)` → `contain` + padding ; zoom au survol conservé, `scale 1 → 1.05`) |

## Vérifications
- `npx tsc --noEmit` ✅ · `npx jest` → **225 tests verts** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)