### PR TITLE
feat(formulaires): modèles prêts à l'emploi + brief « Site vitrine »

### DIFF
--- a/src/views/app/admin/forms/edit/EditForm.tsx
+++ b/src/views/app/admin/forms/edit/EditForm.tsx
@@ -5,6 +5,8 @@ import { HiOutlineEye, HiX } from 'react-icons/hi';
 
 import { Field, BannerConfig, FormStructure, FieldWidth } from './types';
 import { getFieldDef, FIELD_DEFS } from './fieldDefs';
+import { FORM_TEMPLATES, FormTemplate } from './templates';
+import { HiOutlineTemplate } from 'react-icons/hi';
 import { JSONValue } from '@/@types/form';
 
 import Sidebar from './components/Sidebar';
@@ -85,6 +87,7 @@ export default function EditForm({ onValidate, onCancel, fields, name }: Props) 
   const [structure, setStructure] = useState<FormStructure>(() => parseStructure(fields));
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [showPreview, setShowPreview] = useState(false);
+  const [templatesOpen, setTemplatesOpen] = useState(false);
 
   const { banner = {}, fields: formFields } = structure;
   const selectedField = formFields.find((f) => f.id === selectedId) ?? null;
@@ -106,6 +109,23 @@ export default function EditForm({ onValidate, onCancel, fields, name }: Props) 
     const field = makeField(type);
     setFields((prev) => [...prev, field]);
     setSelectedId(field.id);
+  };
+
+  // Insère les champs d'un modèle (id frais) et pré-remplit le nom si vide.
+  const applyTemplate = (tpl: FormTemplate) => {
+    const newFields: Field[] = tpl.fields.map((f) => ({
+      id: genId(f.type),
+      type: f.type,
+      label: f.label,
+      required: f.required ?? false,
+      width: (f.width ?? 100) as FieldWidth,
+      ...(f.placeholder ? { placeholder: f.placeholder } : {}),
+      ...(f.description ? { description: f.description } : {}),
+      ...(f.options ? { options: f.options } : {}),
+    }));
+    setFields((prev) => [...prev, ...newFields]);
+    setFormName((n) => (n && n.trim() ? n : tpl.formName));
+    setTemplatesOpen(false);
   };
 
   const duplicateField = (id: string) => {
@@ -226,6 +246,64 @@ export default function EditForm({ onValidate, onCancel, fields, name }: Props) 
         >
           {formFields.length} champ{formFields.length !== 1 ? 's' : ''}
         </span>
+
+        {/* Modèles prêts à l'emploi */}
+        <div style={{ position: 'relative', flexShrink: 0 }}>
+          <button
+            onClick={() => setTemplatesOpen((o) => !o)}
+            style={{
+              display: 'flex', alignItems: 'center', gap: '6px',
+              padding: '8px 16px',
+              background: templatesOpen ? 'rgba(47,111,237,0.18)' : 'rgba(255,255,255,0.06)',
+              border: '1px solid rgba(47,111,237,0.35)',
+              borderRadius: '9px',
+              color: templatesOpen ? '#7eb3ff' : 'rgba(255,255,255,0.75)',
+              fontSize: '13px', fontWeight: 600, cursor: 'pointer',
+              fontFamily: 'Inter, sans-serif', transition: 'all 0.15s',
+            }}
+          >
+            <HiOutlineTemplate size={15} /> Modèles
+          </button>
+          {templatesOpen && (
+            <>
+              {/* clic extérieur pour fermer */}
+              <div
+                onClick={() => setTemplatesOpen(false)}
+                style={{ position: 'fixed', inset: 0, zIndex: 40 }}
+              />
+              <div style={{
+                position: 'absolute', top: 'calc(100% + 8px)', right: 0, zIndex: 41,
+                width: '260px', background: '#0f1a2c',
+                border: '1px solid rgba(255,255,255,0.12)', borderRadius: '12px',
+                boxShadow: '0 16px 40px rgba(0,0,0,0.5)', padding: '6px',
+                fontFamily: 'Inter, sans-serif',
+              }}>
+                <p style={{ margin: '6px 10px 8px', fontSize: '11px', fontWeight: 700, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.4)' }}>
+                  Insérer un modèle
+                </p>
+                {FORM_TEMPLATES.map((tpl) => (
+                  <button
+                    key={tpl.key}
+                    onClick={() => applyTemplate(tpl)}
+                    style={{
+                      display: 'block', width: '100%', textAlign: 'left',
+                      padding: '10px 12px', borderRadius: '9px',
+                      background: 'transparent', border: 'none', cursor: 'pointer',
+                      transition: 'background 0.12s',
+                    }}
+                    onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(47,111,237,0.14)')}
+                    onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+                  >
+                    <span style={{ display: 'block', color: '#fff', fontSize: '13.5px', fontWeight: 600 }}>{tpl.label}</span>
+                    <span style={{ display: 'block', color: 'rgba(255,255,255,0.45)', fontSize: '12px', marginTop: '2px' }}>
+                      {tpl.description} · {tpl.fields.length} champs
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
 
         {/* Preview */}
         <button

--- a/src/views/app/admin/forms/edit/templates.ts
+++ b/src/views/app/admin/forms/edit/templates.ts
@@ -1,0 +1,63 @@
+import { FieldWidth, Option } from './types';
+
+/**
+ * Modèles de formulaires prêts à l'emploi.
+ *
+ * Un clic sur « Modèles » dans l'éditeur insère ces champs (avec des id frais)
+ * et pré-remplit le nom du formulaire s'il est vide. L'admin ajuste ensuite
+ * librement, puis attache le formulaire à un produit.
+ */
+
+export type TemplateField = {
+  type: string;
+  label: string;
+  required?: boolean;
+  width?: FieldWidth;
+  placeholder?: string;
+  description?: string;
+  options?: Option[];
+};
+
+export type FormTemplate = {
+  key: string;
+  label: string;
+  description: string;
+  formName: string;
+  fields: TemplateField[];
+};
+
+const opt = (labels: string[]): Option[] =>
+  labels.map((l) => ({ label: l, value: l.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '') }));
+
+export const FORM_TEMPLATES: FormTemplate[] = [
+  {
+    key: 'site-vitrine',
+    label: 'Site internet vitrine',
+    description: 'Brief complet pour la création d’un site vitrine',
+    formName: 'Brief — Site internet vitrine',
+    fields: [
+      { type: 'textfield', label: "Nom de l'entreprise / du projet", required: true, width: 50 },
+      { type: 'textfield', label: "Secteur d'activité", width: 50 },
+      { type: 'textfield', label: 'Nom de domaine souhaité', placeholder: 'ex : mon-entreprise.fr', width: 50 },
+      { type: 'select', label: 'Avez-vous déjà un logo ?', width: 50, options: opt(['Oui', 'Non', 'À créer']) },
+      { type: 'file', label: 'Logo (si disponible)', description: 'Formats acceptés : PNG, SVG, JPG' },
+      {
+        type: 'checkboxgroup', label: 'Pages souhaitées',
+        options: opt(['Accueil', 'À propos', 'Services / Prestations', 'Galerie / Réalisations', 'Tarifs', 'Blog / Actualités', 'Contact']),
+      },
+      {
+        type: 'checkboxgroup', label: 'Fonctionnalités souhaitées',
+        options: opt(['Formulaire de contact', 'Carte Google Maps', 'Liens réseaux sociaux', 'Galerie photos', 'Espace téléchargement', 'Site multilingue', 'Prise de rendez-vous']),
+      },
+      { type: 'textarea', label: 'Présentez votre activité', description: 'Le texte à mettre en avant sur le site' },
+      { type: 'textfield', label: 'Couleurs / charte graphique souhaitées', placeholder: 'ex : bleu marine + doré', width: 50 },
+      { type: 'select', label: 'Fournissez-vous les textes et photos ?', width: 50, options: opt(['Oui, tout est prêt', 'Partiellement', 'Non, à créer']) },
+      { type: 'textarea', label: 'Sites qui vous inspirent', placeholder: 'Collez les liens de sites que vous aimez' },
+      { type: 'select', label: 'Délai souhaité', width: 50, options: opt(['Moins de 2 semaines', '2 à 4 semaines', '1 à 2 mois', 'Flexible']) },
+      { type: 'select', label: 'Budget indicatif', width: 50, options: opt(['Moins de 500 €', '500 – 1000 €', '1000 – 2000 €', 'Plus de 2000 €', 'À définir ensemble']) },
+      { type: 'email', label: 'Email de contact', required: true, width: 50 },
+      { type: 'phoneNumber', label: 'Téléphone', width: 50 },
+      { type: 'textarea', label: 'Précisions / demandes particulières' },
+    ],
+  },
+];

--- a/src/views/app/customer/catalogue/components/SubCategoryCard.tsx
+++ b/src/views/app/customer/catalogue/components/SubCategoryCard.tsx
@@ -44,20 +44,21 @@ const SubCategoryCard = ({ data }: { data: ProductCategory }) => {
         fontFamily: 'Inter, sans-serif',
       }}
     >
-      {/* Zone image */}
-      <div style={{ position: 'relative', height: '195px', overflow: 'hidden', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      {/* Zone image — fond blanc + `contain` : les visuels produit (souvent
+          sur fond blanc) s'affichent en entier, centrés, sans être rognés ni
+          noyés. Le voile sombre a été retiré : sur une photo blanche il créait
+          un dégradé grisâtre disgracieux. */}
+      <div style={{ position: 'relative', height: '195px', overflow: 'hidden', background: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         {image?.url ? (
           <img
             ref={imgRef}
             src={image.url}
             alt={name}
-            style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block', transition: 'transform 0.5s ease' }}
+            style={{ width: '100%', height: '100%', objectFit: 'contain', padding: '18px', boxSizing: 'border-box', display: 'block', transition: 'transform 0.5s ease' }}
           />
         ) : (
           <div style={{ position: 'absolute', inset: 0, background: 'radial-gradient(circle at 50% 35%, #20243f 0%, #0e1120 75%)' }} />
         )}
-        {/* léger voile bas pour fondre avec le pied de carte */}
-        <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(to bottom, transparent 55%, rgba(14,17,32,0.85) 100%)', pointerEvents: 'none' }} />
 
         {/* Pastille icône */}
         <div style={{


### PR DESCRIPTION
Ajoute des **modèles de formulaires en 1 clic** dans l'éditeur (`/admin/forms`), avec un premier gabarit **« Site internet vitrine »**.

## Comment ça marche
Dans l'éditeur de formulaire, un nouveau bouton **« Modèles »** ouvre un menu. Un clic sur un modèle :
- insère tous ses champs (avec des id frais),
- pré-remplit le nom du formulaire s'il est vide.

L'admin ajuste ensuite librement (le modèle n'est qu'un point de départ), puis **attache le formulaire au produit** dans la fiche produit.

## Modèle « Site internet vitrine » (16 champs)
Brief complet : nom de l'entreprise, secteur, nom de domaine, logo (upload), pages souhaitées, fonctionnalités (contact, Maps, réseaux, multilingue…), présentation de l'activité, charte graphique, sites inspirants, fourniture textes/photos, délai, budget, email + téléphone, précisions.

## Extensible
`src/views/app/admin/forms/edit/templates.ts` — ajouter un gabarit = ajouter un objet au tableau `FORM_TEMPLATES` (textile, grand format, objets pub…).

## Vérifications
- `npx tsc --noEmit` ✅ · `npx jest` → **225 tests verts** ✅ · `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3mL15pLpBeRsL73HKmc6H)_